### PR TITLE
ISSUE-10: Administrator can turn on/off displaying CSAs name and/or title in End Users chat

### DIFF
--- a/DSL.DMapper/return_first_is_csa_name_visible_from_array.hbs
+++ b/DSL.DMapper/return_first_is_csa_name_visible_from_array.hbs
@@ -1,0 +1,3 @@
+{
+    "isVisible": {{configurationArray.0.value}}
+}

--- a/DSL.DMapper/return_first_is_csa_title_visible_from_array.hbs
+++ b/DSL.DMapper/return_first_is_csa_title_visible_from_array.hbs
@@ -1,0 +1,3 @@
+{
+    "isVisible": {{configurationArray.0.value}}
+}

--- a/DSL.Ruuter.private/DSL/GET/cs-get-csa-name-visibility.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-csa-name-visibility.yml
@@ -1,0 +1,48 @@
+extractRequestData:
+  assign:
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    # TODO: replace with env variable and correct path to TIM endpoint
+    url: http://byk-private-ruuter-yml:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      # TODO: pass cookie name correctly to TIM
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    # TODO: use correct structure when request is made against TIM
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getConfigurationValue
+  next: returnUnauthorized
+
+getConfigurationValue:
+  call: http.post
+  args:
+    # TODO: replace with env variable
+    url: https://byk-resql:8443/get-configuration
+    body:
+      key: "is_csa_name_visible"
+  result: getConfigurationValueResult
+
+mapData:
+  call: http.post
+  args:
+    # TODO: replace with env variable
+    url: https://byk-dmapper:8443/json/v2/return_first_is_csa_name_visible_from_array
+    body:
+      configurationArray: ${getConfigurationValueResult.response.body}
+  result: dataMapperData
+  next: returnSuccess
+
+returnSuccess:
+  return: ${dataMapperData.response.body}
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"

--- a/DSL.Ruuter.private/DSL/GET/cs-get-csa-title-visibility.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-csa-title-visibility.yml
@@ -1,0 +1,48 @@
+extractRequestData:
+  assign:
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    # TODO: replace with env variable and correct path to TIM endpoint
+    url: http://byk-private-ruuter-yml:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      # TODO: pass cookie name correctly to TIM
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    # TODO: use correct structure when request is made against TIM
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getConfigurationValue
+  next: returnUnauthorized
+
+getConfigurationValue:
+  call: http.post
+  args:
+    # TODO: replace with env variable
+    url: https://byk-resql:8443/get-configuration
+    body:
+      key: "is_csa_title_visible"
+  result: getConfigurationValueResult
+
+mapData:
+  call: http.post
+  args:
+    # TODO: replace with env variable
+    url: https://byk-dmapper:8443/json/v2/return_first_is_csa_title_visible_from_array
+    body:
+      configurationArray: ${getConfigurationValueResult.response.body}
+  result: dataMapperData
+  next: returnSuccess
+
+returnSuccess:
+  return: ${dataMapperData.response.body}
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"

--- a/DSL.Ruuter.private/DSL/POST/cs-set-csa-name-visibility.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-csa-name-visibility.yml
@@ -1,0 +1,42 @@
+extractRequestData:
+  assign:
+    isVisible: ${incoming.body.isVisible}
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    # TODO: replace with env variable and correct path to TIM endpoint
+    url: http://byk-private-ruuter-yml:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      # TODO: pass cookie name correctly to TIM
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    # TODO: use correct structure when request is made against TIM
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: setConfigurationValue
+  next: returnFailure
+
+setConfigurationValue:
+  call: http.post
+  args:
+    # TODO: replace with env variable
+    url: https://byk-resql:8443/set-configuration-value
+    body:
+      created: ${new Date().toISOString()}
+      key: "is_csa_name_visible"
+      value: ${isVisible}
+  result: setConfigurationResult
+  next: returnSuccess
+
+returnSuccess:
+  return: ${setConfigurationResult.response.body}
+  next: end
+
+returnFailure:
+  return: "error: unauthorized"

--- a/DSL.Ruuter.private/DSL/POST/cs-set-csa-title-visibility.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-csa-title-visibility.yml
@@ -1,0 +1,42 @@
+extractRequestData:
+  assign:
+    isVisible: ${incoming.body.isVisible}
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    # TODO: replace with env variable and correct path to TIM endpoint
+    url: http://byk-private-ruuter-yml:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      # TODO: pass cookie name correctly to TIM
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    # TODO: use correct structure when request is made against TIM
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: setConfigurationValue
+  next: returnFailure
+
+setConfigurationValue:
+  call: http.post
+  args:
+    # TODO: replace with env variable
+    url: https://byk-resql:8443/set-configuration-value
+    body:
+      created: ${new Date().toISOString()}
+      key: "is_csa_title_visible"
+      value: ${isVisible}
+  result: setConfigurationResult
+  next: returnSuccess
+
+returnSuccess:
+  return: ${setConfigurationResult.response.body}
+  next: end
+
+returnFailure:
+  return: "error: unauthorized"

--- a/DSL.Ruuter.private/DSL/POST/mocks/mock-tim-custom-jwt-userinfo.yml
+++ b/DSL.Ruuter.private/DSL/POST/mocks/mock-tim-custom-jwt-userinfo.yml
@@ -1,0 +1,20 @@
+mockValue:
+  call: reflect.mock
+  args:
+    response:
+      sub: ""
+      firstName: "MARY ÄNN"
+      idCode: "EE60001019906"
+      displayName: "MARY ÄNN"
+      iss: "test.buerokratt.ee"
+      exp: 1670250948
+      login: "EE60001019906"
+      iat: 1670243748
+      jti: "e14a5084-3b30-4a55-8720-c2ee22f43c2c"
+      authorities: [
+          "ROLE_ADMINISTRATOR"
+      ]
+  result: reflectedRequest
+
+returnMockValue:
+  return: ${reflectedRequest.response.body}


### PR DESCRIPTION
Add the following Ruuter endpoints:

POST /cs-set-csa-name-visibility
POST /cs-set-csa-title-visibility
GET /cs-get-csa-name-visibility
GET /cs-get-csa-title-visibility