### PR TITLE
47 end user typed text seen by csa while typed

### DIFF
--- a/GUI/package-lock.json
+++ b/GUI/package-lock.json
@@ -6422,8 +6422,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/GUI/package.json
+++ b/GUI/package.json
@@ -32,6 +32,7 @@
     "framer-motion": "^8.5.5",
     "i18next": "^22.4.5",
     "i18next-browser-languagedetector": "^7.0.1",
+    "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.2.0",
@@ -48,6 +49,7 @@
     "zustand": "^4.3.2"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.191",
     "@types/lodash.debounce": "^4.0.7",
     "@types/node": "^18.11.17",
     "@types/react": "^18.0.26",

--- a/GUI/src/components/Chat/Chat.scss
+++ b/GUI/src/components/Chat/Chat.scss
@@ -260,6 +260,11 @@
     }
   }
 
+  &__message-preview {
+    color: #4472C4;
+    background-color: #E7F3FF;
+  }
+
   &__message-date {
     color: get-color(black-coral-6);
     font-size: 11px;

--- a/GUI/src/components/Chat/ChatMessage.tsx
+++ b/GUI/src/components/Chat/ChatMessage.tsx
@@ -16,13 +16,13 @@ type ChatMessageProps = {
 const ChatMessage: FC<ChatMessageProps> = ({message, onSelect, readStatus}) => {
     const [selected, setSelected] = useState(false);
 
-    return (
+   return (
         <div className={clsx('active-chat__messageContainer')}>
             <div className={clsx('active-chat__message', {'active-chat__message--selected': selected})}>
-                <div className='active-chat__message-text' onClick={() => {
+                <div className={clsx('active-chat__message-text', !!message.preview && 'active-chat__message-preview')} onClick={() => {
                     setSelected(!selected);
                     onSelect(message);
-                }}>{message.content}</div>
+                }}>{message.content}{!!message.preview && message.preview}</div>
                 <time dateTime={message.authorTimestamp} className='active-chat__message-date'>
                     {format(new Date(message.authorTimestamp), 'HH:ii:ss')}
                 </time>
@@ -38,7 +38,7 @@ const ChatMessage: FC<ChatMessageProps> = ({message, onSelect, readStatus}) => {
                       dateTime={readStatus.current.readTime}> {format(new Date(readStatus.current.readTime), 'HH:ii:ss')}</time></span>
             ) : null}
         </div>
-    );
+    )
 };
 
 export default ChatMessage;

--- a/GUI/src/components/Chat/index.tsx
+++ b/GUI/src/components/Chat/index.tsx
@@ -1,4 +1,4 @@
-import {FC, useEffect, useMemo, useRef, useState} from 'react';
+import {FC, useEffect, useMemo, useRef, useState, useTransition} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useQuery} from '@tanstack/react-query';
 import {format} from 'date-fns';
@@ -9,12 +9,12 @@ import {Button, FormInput, Icon, Track} from 'components';
 import {ReactComponent as BykLogoWhite} from 'assets/logo-white.svg';
 import useUserInfoStore from 'store/store';
 import {Chat as ChatType, MessageSseEvent, MessageStatus} from 'types/chat';
-import {Message} from 'types/message';
+import {Message, MessagePreviewSseResponse} from 'types/message';
 import ChatMessage from './ChatMessage';
 import ChatEvent from './ChatEvent';
 import './Chat.scss';
 import handleSse from "../../mocks/handleSse";
-
+import {findIndex} from 'lodash';
 
 
 type ChatProps = {
@@ -35,7 +35,13 @@ const Chat: FC<ChatProps> = ({chat, onChatEnd, onForwardToColleauge, onForwardTo
         const {t} = useTranslation();
         const {userInfo} = useUserInfoStore();
         const chatRef = useRef<HTMLDivElement>(null);
-        const [messageGroups, setMessageGroups] = useState<GroupedMessage[]>([]);
+        const [messageGroups, _setMessageGroups] = useState<GroupedMessage[]>([]);
+        const messageGroupsRef = useRef(messageGroups);
+        const setMessageGroups = (data: GroupedMessage[]) => {
+            messageGroupsRef.current = data;
+            _setMessageGroups(data);
+        };
+        const [isPending, startTransition] = useTransition();
         const [responseText, setResponseText] = useState('');
         const [selectedMessages, setSelectedMessages] = useState<Message[]>([]);
         const {data: messages} = useQuery<Message[]>({
@@ -51,6 +57,30 @@ const Chat: FC<ChatProps> = ({chat, onChatEnd, onForwardToColleauge, onForwardTo
             messageReadStatusRef.current = data;
             _setMessageReadStatus(data);
         };
+
+
+        const setPreviewMessage = (event: MessagePreviewSseResponse) => {
+            const PREVIEW_MESSAGE:GroupedMessage = {
+                name: endUserFullName,
+                type: event.data.authorRole,
+                messages: event.data as any, // TODO fix types
+            };
+            const CURRENT_MESSAGE_GROUPS = messageGroupsRef.current;
+            const index = findIndex(CURRENT_MESSAGE_GROUPS, (o) => o.messages[0].id === PREVIEW_MESSAGE.messages[0].id);
+
+            if (index === -1) {
+                CURRENT_MESSAGE_GROUPS.push(PREVIEW_MESSAGE);
+                startTransition(() => {
+                    setMessageGroups(CURRENT_MESSAGE_GROUPS)
+                })
+            } else {
+                CURRENT_MESSAGE_GROUPS.splice(index, 1, PREVIEW_MESSAGE);
+                startTransition(() => {
+                    setMessageGroups(CURRENT_MESSAGE_GROUPS)
+                })
+            }
+        };
+
 
         const hasAccessToActions = useMemo(() => {
             if (chat.customerSupportId === userInfo?.idCode) return true;
@@ -102,17 +132,22 @@ const Chat: FC<ChatProps> = ({chat, onChatEnd, onForwardToColleauge, onForwardTo
         useEffect(() => {
                 const sseResponse = handleSse();
                 sseResponse.addEventListener(MessageSseEvent.READ, (event: any) => {
-
                     setMessageReadStatus({
                         messageId: event.data.id,
                         readTime: event.data.created,
                     })
                 });
+
+                sseResponse.addEventListener(MessageSseEvent.PREVIEW, (event: MessagePreviewSseResponse) => {
+                    setPreviewMessage(event);
+                });
+
                 return () => {
                     sseResponse.close();
                 };
             }, []
         );
+
         return (
             <div className='active-chat'>
                 <div className='active-chat__body'>

--- a/GUI/src/mocks/chatMessagesPreviewNewSse.ts
+++ b/GUI/src/mocks/chatMessagesPreviewNewSse.ts
@@ -1,0 +1,61 @@
+export const chatMessagesPreviewNew1Sse = [
+    {
+        id: "944648e5-9816-4bca-b600-a2db5d977758",
+        chatid: "50356c0c-b0ec-45cc-9601-fac90307b792",
+        content: "",
+        event: "message-preview",
+        authorId: "",
+        authorTimestamp: '2023-01-23T15:13:42.830+00:00',
+        authorFirstName: "",
+        authorLastName: "",
+        authorRole: "end-user",
+        forwardedByUser: "",
+        forwardedFromCsa: "",
+        forwardedToCsa: "",
+        preview: "Mul on vaja abi",
+        rating: "",
+        created: '2023-01-23T15:13:42.830+00:00',
+        updated: '2023-01-23T15:13:42.837+00:00',
+    }]
+
+export const chatMessagesPreviewNew2Sse = [
+    {
+        id: "944648e5-9816-4bca-b600-a2db5d977758",
+        chatid: "50356c0c-b0ec-45cc-9601-fac90307b792",
+        content: "",
+        event: "message-preview",
+        authorId: "",
+        authorTimestamp: '2023-01-23T15:13:42.830+00:00',
+        authorFirstName: "",
+        authorLastName: "",
+        authorRole: "end-user",
+        forwardedByUser: "",
+        forwardedFromCsa: "",
+        forwardedToCsa: "",
+        preview: "Mul on vaja abi ühe asjaga",
+        rating: "",
+        created: '2023-01-23T15:13:42.830+00:00',
+        updated: '2023-01-23T15:13:42.837+00:00',
+    }
+];
+
+export const chatMessagesPreviewNew3Sse = [
+    {
+        id: "944648e5-9816-4bca-b600-a2db5d977758",
+        chatid: "50356c0c-b0ec-45cc-9601-fac90307b792",
+        content: "",
+        event: "message-preview",
+        authorId: "",
+        authorTimestamp: '2023-01-23T15:13:42.830+00:00',
+        authorFirstName: "",
+        authorLastName: "",
+        authorRole: "end-user",
+        forwardedByUser: "",
+        forwardedFromCsa: "",
+        forwardedToCsa: "",
+        preview: "Mul on vaja abi ühe asjaga, mis on väga oluline!",
+        rating: "",
+        created: '2023-01-23T15:13:42.830+00:00',
+        updated: '2023-01-23T15:13:42.837+00:00',
+    }
+];

--- a/GUI/src/mocks/chatMessagesSeenSse.ts
+++ b/GUI/src/mocks/chatMessagesSeenSse.ts
@@ -1,4 +1,4 @@
-export const chatMessagesSeen = {
+export const chatMessagesSeenSse = {
     // "id": "0e6c2a27-fbc1-4f07-9c84-e941af4fce51",
     "id": "a4a47f36-57e5-f25a-7a48-dd019096d08b",
     "chatid": "7045872f-bb09-4b8e-8dd0-76783983792b",

--- a/GUI/src/mocks/handleSse.ts
+++ b/GUI/src/mocks/handleSse.ts
@@ -1,31 +1,33 @@
 // @ts-ignore npm i --save-dev @types/mocksse does not exist
 import {MockEvent, EventSource} from 'mocksse';
-import {chatMessagesSeen} from "./chatMessagesSeen";
-import {MessageSseEvent} from "../types/chat";
+import {chatMessagesSeenSse} from "./chatMessagesSeenSse";
 
-/*
-TODO: find out how to set
-{ withCredentials: true }
-*/
+import {MessageSseEvent} from "../types/chat";
+import {chatMessagesPreviewNew1Sse,chatMessagesPreviewNew2Sse,chatMessagesPreviewNew3Sse} from "./chatMessagesPreviewNewSse";
+
 
 const handleSse = () => {
     new MockEvent({
         // TODO: set correct url
         url: 'http://localhost:3000/cs-get-new-messages',
-        setInterval: 3_000,
+        setInterval: [3_000, 2_000, 3_000, 4_000],
         responses: [
-            {type: MessageSseEvent.READ, data: chatMessagesSeen},
+            {type: MessageSseEvent.READ, data: chatMessagesSeenSse},
             // {type: MessageSseEvent.DELIVERED, data: chatMessagesSeen},
+            {type: MessageSseEvent.PREVIEW, data: chatMessagesPreviewNew1Sse },
+            {type: MessageSseEvent.PREVIEW, data: chatMessagesPreviewNew2Sse },
+            {type: MessageSseEvent.PREVIEW, data: chatMessagesPreviewNew3Sse },
         ]
     });
 
     // TODO: set correct url
-    return new EventSource('http://localhost:3000/cs-get-new-messages');
+    return new EventSource('http://localhost:3000/cs-get-new-messages',{
+        withCredentials: true
+    });
 
     // TODO find out what is the event name for message-delivered
     // eventSource.addEventListener(Message.DELIVERED, (event: any) => {
     //     console.log('event message-delivered', event.data.id);
-    //
     // });
 
     //TODO: handle error

--- a/GUI/src/types/chat.ts
+++ b/GUI/src/types/chat.ts
@@ -58,7 +58,8 @@ export interface Chat {
 
 export enum MessageSseEvent {
   READ = 'message-read',
-  DELIVERED = 'message-delivered'
+  DELIVERED = 'message-delivered',
+  PREVIEW = 'message-preview',
 }
 
 export type MessageStatus = {

--- a/GUI/src/types/message.ts
+++ b/GUI/src/types/message.ts
@@ -14,4 +14,12 @@ export interface Message {
   rating?: string;
   created?: string;
   updated?: string;
+
+  preview?: string;
+}
+
+export interface MessagePreviewSseResponse {
+  data: Message;
+  origin: string;
+  type: string;
 }


### PR DESCRIPTION

https://user-images.githubusercontent.com/31508949/219565385-6c0cd9b7-918e-43bc-9a59-ba05277f211e.mov

Implementation in done on the assumption that:

- SSE preview events will have partial message as seen in the video.
- SSE message-preview  has the same "id" as the final message.
- SSE message-preview "chatid" is the one that belongs to that specific chat.

Implementation:

- Currently, SSE message-preview response is added to the messages and updated accordingly. Replaced one the end-user sends the actual message.