### PR TITLE
Replaced hard-coded endpoint values with variables in Ruuter DSLs. FIX

### DIFF
--- a/DSL.Ruuter.private/DSL/GET/comments/comment-history.yml
+++ b/DSL.Ruuter.private/DSL/GET/comments/comment-history.yml
@@ -7,7 +7,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -26,7 +26,7 @@ getChatHistoryComment:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-chat-history-comment-by-id"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-chat-history-comment-by-id"
     body:
       chatId: ${chatId}
   result: getChatHistoryCommentResult
@@ -35,7 +35,7 @@ mapChatHistoryCommentData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_chat_history_comment"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_chat_history_comment"
     body:
       historyComment: ${getChatHistoryCommentResult.response.body}
   result: chatHistoryCommentData

--- a/DSL.Ruuter.private/DSL/GET/cs-get-csa-name-visibility.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-csa-name-visibility.yml
@@ -6,7 +6,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -25,7 +25,7 @@ getConfigurationValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-configuration"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-configuration"
     body:
       key: "is_csa_name_visible"
   result: getConfigurationValueResult
@@ -34,7 +34,7 @@ mapData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_first_is_csa_name_visible_from_array"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_first_is_csa_name_visible_from_array"
     body:
       configurationArray: ${getConfigurationValueResult.response.body}
   result: dataMapperData

--- a/DSL.Ruuter.private/DSL/GET/cs-get-csa-title-visibility.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-csa-title-visibility.yml
@@ -6,7 +6,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -25,7 +25,7 @@ getConfigurationValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-configuration"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-configuration"
     body:
       key: "is_csa_title_visible"
   result: getConfigurationValueResult
@@ -34,7 +34,7 @@ mapData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_first_is_csa_title_visible_from_array"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_first_is_csa_title_visible_from_array"
     body:
       configurationArray: ${getConfigurationValueResult.response.body}
   result: dataMapperData

--- a/DSL.Ruuter.private/DSL/GET/cs-get-emergency-notice.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-emergency-notice.yml
@@ -6,7 +6,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -25,7 +25,7 @@ getEmergencyNotice:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-emergency-notice"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-emergency-notice"
   result: getEmergencyNoticeResult
 
 validateEmergencyNoticeExists:
@@ -38,7 +38,7 @@ mapEmergencyNoticeData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"
     body:
       configurationArray: ${getEmergencyNoticeResult.response.body}
   result: emergencyNoticeData

--- a/DSL.Ruuter.private/DSL/GET/cs-get-end-user-session-length.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-end-user-session-length.yml
@@ -6,7 +6,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_BYK_RUUTER]:[CHATBOT_BYK_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_BYK_RUUTER]:[#CHATBOT_BYK_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -24,7 +24,7 @@ getConfigurationValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-configuration"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-configuration"
     body:
       key: "end_user_session_length"
   result: getConfigurationValueResult
@@ -33,7 +33,7 @@ mapData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_first_configuration_from_array"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_first_configuration_from_array"
     body:
       configurationArray: ${getConfigurationValueResult.response.body}
   result: dataMapperData

--- a/DSL.Ruuter.private/DSL/GET/cs-get-organization-working-time.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-organization-working-time.yml
@@ -6,7 +6,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -25,7 +25,7 @@ getOrganizationWorkingTime:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-organization-working-time"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-organization-working-time"
   result: getOrganizationWorkingTimeValueResult
 
 validateOrganizationWorkingTimeExists:
@@ -38,7 +38,7 @@ mapWorkingTimeData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_organization_working_time"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_organization_working_time"
     headers:
       type: json
     body:

--- a/DSL.Ruuter.private/DSL/GET/cs-get-widget-config.yml
+++ b/DSL.Ruuter.private/DSL/GET/cs-get-widget-config.yml
@@ -6,7 +6,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -25,7 +25,7 @@ getWidgetConfig:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-widget-config"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-widget-config"
   result: getWidgetConfigResult
 
 validateWidgetConfigExists:
@@ -38,7 +38,7 @@ mapWidgetConfigData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_widget_config"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_widget_config"
     body:
       configurationArray: ${getWidgetConfigResult.response.body}
   result: widgetConfigData

--- a/DSL.Ruuter.private/DSL/POST/comments/comment-history.yml
+++ b/DSL.Ruuter.private/DSL/POST/comments/comment-history.yml
@@ -8,7 +8,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -27,7 +27,7 @@ setChatComment:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-chat-history-comment"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-chat-history-comment"
     body:
       comment: ${comment}
       chatId: ${chatId}

--- a/DSL.Ruuter.private/DSL/POST/cs-get-chat-by-id.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-get-chat-by-id.yml
@@ -7,7 +7,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -25,7 +25,7 @@ validateAdministrator:
 getChatById:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-chat-by-id"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-chat-by-id"
     body:
       id: ${chatId}
   result: chatResult
@@ -34,7 +34,7 @@ getChatById:
 formatChatArray:
   call: http.post
   args:
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_first_chat_from_array"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_first_chat_from_array"
     body:
       chatArray: ${chatResult.response.body}
   result: formattedChat

--- a/DSL.Ruuter.private/DSL/POST/cs-get-user-profile-settings.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-get-user-profile-settings.yml
@@ -7,7 +7,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -26,7 +26,7 @@ getUserSettings:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-user-profile-settings"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-user-profile-settings"
     body:
       userId: ${userId}
   result: getUserSettingsResult

--- a/DSL.Ruuter.private/DSL/POST/cs-set-csa-name-visibility.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-csa-name-visibility.yml
@@ -7,7 +7,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -26,7 +26,7 @@ setConfigurationValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/set-configuration-value"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/set-configuration-value"
     body:
       created: ${new Date().toISOString()}
       key: "is_csa_name_visible"

--- a/DSL.Ruuter.private/DSL/POST/cs-set-csa-title-visibility.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-csa-title-visibility.yml
@@ -7,7 +7,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -26,7 +26,7 @@ setConfigurationValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/set-configuration-value"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/set-configuration-value"
     body:
       created: ${new Date().toISOString()}
       key: "is_csa_title_visible"

--- a/DSL.Ruuter.private/DSL/POST/cs-set-emergency-notice.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-emergency-notice.yml
@@ -10,7 +10,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -35,7 +35,7 @@ setEmergencyNotice:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/set-emergency-notice"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/set-emergency-notice"
     body:
       emergencyNoticeText: ${emergencyNoticeText}
       emergencyNoticeStartISO: ${emergencyNoticeStartISO}
@@ -48,7 +48,7 @@ mapEmergencyNoticeData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"
     body:
       configurationArray: ${setEmergencyNoticeResult.response.body}
   result: emergencyNoticeData

--- a/DSL.Ruuter.private/DSL/POST/cs-set-end-user-session-length.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-end-user-session-length.yml
@@ -7,7 +7,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_BYK_RUUTER]:[CHATBOT_BYK_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_BYK_RUUTER]:[#CHATBOT_BYK_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -26,7 +26,7 @@ setConfigurationValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_BYK_RESQL]:[CHATBOT_BYK_RESQL_PORT]/set-configuration-value"
+    url: "[#CHATBOT_BYK_RESQL]:[#CHATBOT_BYK_RESQL_PORT]/set-configuration-value"
     body:
       created: ${new Date().toISOString()}
       key: "end_user_session_length"

--- a/DSL.Ruuter.private/DSL/POST/cs-set-organization-working-time.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-organization-working-time.yml
@@ -10,7 +10,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -35,7 +35,7 @@ setOrganizationWorkingTime:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/set-organization-working-time"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/set-organization-working-time"
     body:
       organizationWorkingTimeStartISO: ${organizationWorkingTimeStartISO}
       organizationWorkingTimeEndISO: ${organizationWorkingTimeEndISO}
@@ -48,7 +48,7 @@ mapOrganizationWorkingTimeData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_organization_working_time"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_organization_working_time"
     headers:
       type: json
     body:

--- a/DSL.Ruuter.private/DSL/POST/cs-set-user-profile-settings.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-user-profile-settings.yml
@@ -14,7 +14,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -33,7 +33,7 @@ setUserSettingValue:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/set-user-profile-settings"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/set-user-profile-settings"
     body:
       userId: ${userId}
       forwardedChatPopupNotifications: ${forwardedChatPopupNotifications}

--- a/DSL.Ruuter.private/DSL/POST/cs-set-widget-config.yml
+++ b/DSL.Ruuter.private/DSL/POST/cs-set-widget-config.yml
@@ -12,7 +12,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -31,7 +31,7 @@ setWidgetConfig:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/set-widget-config"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/set-widget-config"
     body:
       widgetProactiveSeconds: ${widgetProactiveSeconds}
       widgetDisplayBubbleMessageSeconds: ${widgetDisplayBubbleMessageSeconds}
@@ -46,7 +46,7 @@ mapWidgetConfigData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_widget_config"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_widget_config"
     body:
       configurationArray: ${setWidgetConfigResult.response.body}
   result: widgetConfigData

--- a/DSL.Ruuter.private/DSL/POST/end-user-email-phone.yml
+++ b/DSL.Ruuter.private/DSL/POST/end-user-email-phone.yml
@@ -13,7 +13,7 @@ checkChatId:
 insertEmailAndPhone:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/update-chat-with-end-user-email-and-phone"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/update-chat-with-end-user-email-and-phone"
     body:
       chatId: ${chatId}
       endUserEmail: "${email ? email : ''}"

--- a/DSL.Ruuter.private/DSL/POST/end-user-id-name.yml
+++ b/DSL.Ruuter.private/DSL/POST/end-user-id-name.yml
@@ -14,7 +14,7 @@ checkChatId:
 insertIdAndName:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/update-chat-with-end-user-id-and-name"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/update-chat-with-end-user-id-and-name"
     body:
       chatId: ${chatId}
       endUserId: "${id ? id : ''}"

--- a/DSL.Ruuter.private/DSL/POST/history/cs-send-history-to-email.yml
+++ b/DSL.Ruuter.private/DSL/POST/history/cs-send-history-to-email.yml
@@ -6,7 +6,7 @@ getUserEmailByChatId:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-user-email-by-chat-id"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-user-email-by-chat-id"
     body:
       chatId: ${chatId}
   result: getUserEmailByChatIdResult
@@ -16,7 +16,7 @@ getMessagesByChatId:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-chat-messages"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-chat-messages"
     body:
       chatId: ${chatId}
   result: getMessagesByChatIdResult
@@ -26,7 +26,7 @@ mapChatMessages:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/format_chat_log"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/format_chat_log"
     body:
       data: ${getMessagesByChatIdResult.response.body}
   result: chatMessagesData
@@ -36,7 +36,7 @@ sendDataToEmail:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/js/email/sendMockEmail"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/js/email/sendMockEmail"
     body:
       to: ${getUserEmailByChatIdResult.response.body[0].csaEmail}
       subject: "Chat history"
@@ -48,7 +48,7 @@ registerEmailSentEvent:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-message"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-message"
     body:
       chatId: ${chatId}
       messageId: ""

--- a/DSL.Ruuter.private/DSL/POST/labels/label-history.yml
+++ b/DSL.Ruuter.private/DSL/POST/labels/label-history.yml
@@ -8,7 +8,7 @@ extractTokenData:
   call: http.post
   args:
     # TODO: replace with env variable and correct path to TIM endpoint
-    url: "[CHATBOT_RUUTER]:[CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
+    url: "[#CHATBOT_RUUTER]:[#CHATBOT_RUUTER_PORT]/mocks/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -27,7 +27,7 @@ setChatLabels:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-chat-history-labels"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-chat-history-labels"
     body:
       labels: ${labels}
       chatId: ${chatId}

--- a/DSL.Ruuter.public/DSL/GET/get-all-available-customer-support-agents.yml
+++ b/DSL.Ruuter.public/DSL/GET/get-all-available-customer-support-agents.yml
@@ -2,7 +2,7 @@ getAvailableCustomerSupportAgents:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-all-available-customer-support-agents"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-all-available-customer-support-agents"
   result: getAvailableCustomerSupportAgentsResult
 
 return_result:

--- a/DSL.Ruuter.public/DSL/GET/get-emergency-notice.yml
+++ b/DSL.Ruuter.public/DSL/GET/get-emergency-notice.yml
@@ -2,7 +2,7 @@ getEmergencyNotice:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-emergency-notice"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-emergency-notice"
   result: getEmergencyNoticeResult
 
 validateEmergencyNoticeExists:
@@ -15,7 +15,7 @@ mapEmergencyNoticeData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"
     body:
       configurationArray: ${getEmergencyNoticeResult.response.body}
   result: emergencyNoticeData

--- a/DSL.Ruuter.public/DSL/GET/get-organization-working-time.yml
+++ b/DSL.Ruuter.public/DSL/GET/get-organization-working-time.yml
@@ -2,7 +2,7 @@ getOrganizationWorkingTime:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-organization-working-time"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-organization-working-time"
   result: getOrganizationWorkingTimeValueResult
 
 validateOrganizationWorkingTimeExists:
@@ -15,7 +15,7 @@ mapWorkingTimeData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_organization_working_time"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_organization_working_time"
     headers:
       type: json
     body:

--- a/DSL.Ruuter.public/DSL/GET/get-widget-config.yml
+++ b/DSL.Ruuter.public/DSL/GET/get-widget-config.yml
@@ -2,7 +2,7 @@ getWidgetConfig:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-widget-config"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-widget-config"
   result: getWidgetConfigResult
 
 validateWidgetConfigExists:
@@ -15,7 +15,7 @@ mapWidgetConfigData:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_widget_config"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_widget_config"
     body:
       configurationArray: ${getWidgetConfigResult.response.body}
   result: widgetConfigData

--- a/DSL.Ruuter.public/DSL/POST/download-chat.yml
+++ b/DSL.Ruuter.public/DSL/POST/download-chat.yml
@@ -7,7 +7,7 @@ getMessagesByChatId:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-chat-messages"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-chat-messages"
     body:
       chatId: ${chatId}
   result: getMessagesByChatIdResult
@@ -17,7 +17,7 @@ mapChatMessages:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/format_chat_log"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/format_chat_log"
     body:
       data: ${getMessagesByChatIdResult.response.body}
   result: formattedChatMessages
@@ -27,7 +27,7 @@ convertDataToPdf:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/js/convert/pdf"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/js/convert/pdf"
     body:
       data: ${formattedChatMessages.response.body}
   result: pdfFile
@@ -50,7 +50,7 @@ sendPdfToEmail:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/js/email/sendMockEmail"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/js/email/sendMockEmail"
     body:
       to: ${email}
       subject: "Chat history"

--- a/DSL.Ruuter.public/DSL/POST/end-user-email-phone.yml
+++ b/DSL.Ruuter.public/DSL/POST/end-user-email-phone.yml
@@ -13,7 +13,7 @@ checkChatId:
 insertEmailAndPhone:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/update-chat-with-end-user-email-and-phone"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/update-chat-with-end-user-email-and-phone"
     body:
       chatId: ${chatId}
       endUserEmail: "${email ? email : ''}"

--- a/DSL.Ruuter.public/DSL/POST/end-user-id-name.yml
+++ b/DSL.Ruuter.public/DSL/POST/end-user-id-name.yml
@@ -14,7 +14,7 @@ checkChatId:
 insertIdAndName:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/update-chat-with-end-user-id-and-name"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/update-chat-with-end-user-id-and-name"
     body:
       chatId: ${chatId}
       endUserId: "${id ? id : ''}"

--- a/DSL.Ruuter.public/DSL/POST/estimated-waiting-time.yml
+++ b/DSL.Ruuter.public/DSL/POST/estimated-waiting-time.yml
@@ -6,14 +6,14 @@ getDurationTotalInSeconds:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_BYK_RESQL]:[CHATBOT_BYK_RESQL_PORT]/get-ended-chats-total-duration-in-seconds"
+    url: "[#CHATBOT_BYK_RESQL]:[#CHATBOT_BYK_RESQL_PORT]/get-ended-chats-total-duration-in-seconds"
   result: durationTotalInSeconds
 
 getUnassignedChats:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_BYK_RESQL]:[CHATBOT_BYK_RESQL_PORT]/get-unassigned-chat-total-with-position-by-chat-id"
+    url: "[#CHATBOT_BYK_RESQL]:[#CHATBOT_BYK_RESQL_PORT]/get-unassigned-chat-total-with-position-by-chat-id"
     body:
       chatId: "${chatId ? chatId : ''}"
   result: unassignedChats
@@ -36,7 +36,7 @@ getEstimatedWaitingTime:
   call: http.post
   args:
     # TODO: replace with env variable
-    url: "[CHATBOT_BYK_DMAPPER]:[CHATBOT_BYK_DMAPPER_PORT]/json/v2/reflect_waiting_time"
+    url: "[#CHATBOT_BYK_DMAPPER]:[#CHATBOT_BYK_DMAPPER_PORT]/json/v2/reflect_waiting_time"
     body:
       durationInSeconds: '${calculatedDuration}'
       positionInUnassignedChats: '${position}'

--- a/DSL.Ruuter.public/DSL/POST/post-message-to-bot.yml
+++ b/DSL.Ruuter.public/DSL/POST/post-message-to-bot.yml
@@ -15,7 +15,7 @@ extractRequestData:
 check_bot_is_active:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-configuration"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-configuration"
     body:
       key: "is_bot_active"
   result: is_bot_active_result
@@ -30,7 +30,7 @@ check_for_bot_active_result:
 get_bot_name:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-configuration"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-configuration"
     body:
       key: "bot_institution_id"
   result: get_bot_name_result
@@ -45,7 +45,7 @@ check_for_bot_name_result:
 get_chat:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-chat-by-id"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-chat-by-id"
     body:
       id: ${chatId}
   result: get_chat_result
@@ -88,7 +88,7 @@ check_if_bot_is_unable_to_reply:
 get_organization_working_details:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-is-organization-available"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-is-organization-available"
     body:
       holidays: ${holidays}
       holiday_names: ${holiday_names}
@@ -103,7 +103,7 @@ assign_organization_details:
 getCurrentInstant:
   call: http.post
   args:
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_instant"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_instant"
     headers:
       type: json
   result: current_instant_res
@@ -122,7 +122,7 @@ check_if_organization_is_available:
 return_is_a_holiday:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-bot-message"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-bot-message"
     body:
       messages: 
          -
@@ -140,7 +140,7 @@ return_is_a_holiday:
 return_organization_is_not_available:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-bot-message"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-bot-message"
     body:
       messages: 
          -
@@ -158,7 +158,7 @@ return_organization_is_not_available:
 get_all_available_csas:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/get-all-available-customer-support-agents"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/get-all-available-customer-support-agents"
   result: csas_res
   next: assign_available_csas
 
@@ -176,7 +176,7 @@ check_if_csas_are_available:
 send_csas_not_available_message:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-bot-message"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-bot-message"
     body:
       messages: 
          -
@@ -194,7 +194,7 @@ send_csas_not_available_message:
 redirect_chat_to_back_office:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/remove_cs_agent_from_chat"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/remove_cs_agent_from_chat"
     body:
       chatId: ${chatId}
   result: redirect_chat_to_back_office_result
@@ -203,7 +203,7 @@ redirect_chat_to_back_office:
 getInstant:
   call: http.post
   args:
-    url: "[CHATBOT_DMAPPER_V2]:[CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_instant"
+    url: "[#CHATBOT_DMAPPER_V2]:[#CHATBOT_DMAPPER_V2_PORT]/hbs/chat-bot/return_instant"
     headers:
       type: json
   result: instant_result
@@ -212,7 +212,7 @@ getInstant:
 convert_bot_responses_to_messages:
   call: http.post
   args:
-    url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/bot_responses_to_messages"
+    url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/bot_responses_to_messages"
     body:
       botMessages: ${post_message_to_client_result.response.body}
       chatId: ${chatId}
@@ -227,7 +227,7 @@ convert_bot_responses_to_messages:
 add_bot_message_to_db:
   call: http.post
   args:
-    url: "[CHATBOT_RESQL]:[CHATBOT_RESQL_PORT]/insert-bot-message"
+    url: "[#CHATBOT_RESQL]:[#CHATBOT_RESQL_PORT]/insert-bot-message"
     body:
       messages: ${converted_messages_return.response.body}
   result: post_message_to_client_result


### PR DESCRIPTION
Latest change added # inside the square brackets for the url. Example -> url: "[CHATBOT_DMAPPER]:[CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice" was changed to url: "[#CHATBOT_DMAPPER]:[#CHATBOT_DMAPPER_PORT]/json/v2/return_emergency_notice"