### PR TITLE
Ruuter-v1 dmapper and resql url changes

### DIFF
--- a/DSL.Ruuter-v1.private/account/cs-add-user.json
+++ b/DSL.Ruuter-v1.private/account/cs-add-user.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_user",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_user",
           "post_body_struct": {
             "firstName": "{#.firstName}",
             "lastName": "{#.lastName}",
@@ -93,7 +93,7 @@
           "post_body_parameters": {
             "get_user": {
               "method": "post",
-              "endpoint": "{resql_url}/get-user",
+              "endpoint": "{resql_url}/backoffice/get-user",
               "post_body_struct": {
                 "userIdCode": "{#.reflect_input#.userIdCode}"
               }
@@ -120,7 +120,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-user",
+          "endpoint": "{resql_url}/backoffice/insert-user",
           "post_body_struct": {
             "created": "$_getInstant()",
             "status": "active",
@@ -144,7 +144,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-user-role",
+          "endpoint": "{resql_url}/backoffice/insert-user-role",
           "post_body_struct": {
             "userIdCode": "{#.reflect_input#.userIdCode}",
             "roles": "{#.reflect_input#.roles}",
@@ -163,7 +163,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-customer-support-status",
+          "endpoint": "{resql_url}/backoffice/set-customer-support-status",
           "post_body_struct": {
             "userIdCode": "{#.reflect_input#.userIdCode}",
             "active": "false",
@@ -183,7 +183,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-user-profile-settings",
+          "endpoint": "{resql_url}/backoffice/set-user-profile-settings",
           "post_body_struct": {
             "userId": "{#.reflect_input#.userIdCode}",
             "forwardedChatPopupNotifications": false,

--- a/DSL.Ruuter-v1.private/account/cs-check-if-user-exists.json
+++ b/DSL.Ruuter-v1.private/account/cs-check-if-user-exists.json
@@ -24,7 +24,7 @@
           "post_body_parameters": {
             "get_user": {
               "method": "post",
-              "endpoint": "{resql_url}/get-user",
+              "endpoint": "{resql_url}/backoffice/get-user",
               "post_body_struct": {
                 "userIdCode": "{#.userIdCode}"
               }

--- a/DSL.Ruuter-v1.private/account/cs-delete-user.json
+++ b/DSL.Ruuter-v1.private/account/cs-delete-user.json
@@ -10,7 +10,7 @@
       },
       "proceed": {
         "method": "post",
-        "endpoint": "{resql_url}/delete-user",
+        "endpoint": "{resql_url}/backoffice/delete-user",
         "post_body_struct": {
           "userIdCode": "{#.userIdCode}",
           "created": "$_getInstant()"

--- a/DSL.Ruuter-v1.private/account/cs-edit-user.json
+++ b/DSL.Ruuter-v1.private/account/cs-edit-user.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_user",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_user",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -69,7 +69,7 @@
           "post_body_parameters": {
             "get_user": {
               "method": "post",
-              "endpoint": "{resql_url}/get-user",
+              "endpoint": "{resql_url}/backoffice/get-user",
               "post_body_struct": {
                 "userIdCode": "{#.reflect_input#.userIdCode}"
               }
@@ -105,7 +105,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/update-user",
+          "endpoint": "{resql_url}/backoffice/update-user",
           "post_body_struct": {
             "created": "$_getInstant()",
             "status": "active",
@@ -129,7 +129,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/update-user-role",
+          "endpoint": "{resql_url}/backoffice/update-user-role",
           "post_body_struct": {
             "userIdCode": "{#.reflect_input#.userIdCode}",
             "roles": "{#.reflect_input#.roles}",

--- a/DSL.Ruuter-v1.private/account/cs-get-admins.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-admins.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-users-with-roles",
+          "endpoint": "{resql_url}/backoffice/get-users-with-roles",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/account/cs-get-customer-support-activity-by-id.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-customer-support-activity-by-id.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-customer-support-activity-by-id-code",
+          "endpoint": "{resql_url}/backoffice/get-customer-support-activity-by-id-code",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/account/cs-get-customer-support-activity.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-customer-support-activity.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-customer-support-activity-by-id-code",
+          "endpoint": "{resql_url}/backoffice/get-customer-support-activity-by-id-code",
           "post_body_parameters": {
             "userinfo": {
               "cookies": [

--- a/DSL.Ruuter-v1.private/account/cs-get-customer-support-agents.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-customer-support-agents.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-users-with-roles-by-role",
+          "endpoint": "{resql_url}/backoffice/get-users-with-roles-by-role",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/account/cs-get-estimated-waiting-time.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-estimated-waiting-time.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-estimated-waiting-time",
+          "endpoint": "{resql_url}/backoffice/get-estimated-waiting-time",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "estimated_waiting_time"
@@ -33,7 +33,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_estimated_time_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_estimated_time_from_array",
           "post_body_struct": {
             "estimatedTimeArray": "{#.get_estimated_waiting_time}"
           }

--- a/DSL.Ruuter-v1.private/account/cs-get-session-length.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-session-length.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-configuration",
+          "endpoint": "{resql_url}/backoffice/get-configuration",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "session_length"

--- a/DSL.Ruuter-v1.private/account/cs-get-user-role.json
+++ b/DSL.Ruuter-v1.private/account/cs-get-user-role.json
@@ -33,7 +33,7 @@
                 },
                 "proceed": {
                     "method": "post",
-                    "endpoint": "{resql_url}/get-user-role",
+                    "endpoint": "{resql_url}/backoffice/get-user-role",
                     "post_body_struct": {
                         "userIdCode": "{#.reflect_input#.idCode}"
                     }

--- a/DSL.Ruuter-v1.private/account/cs-login-with-tara-jwt.json
+++ b/DSL.Ruuter-v1.private/account/cs-login-with-tara-jwt.json
@@ -61,14 +61,14 @@
           "post_body_parameters": {
             "user_with_roles": {
               "method": "post",
-              "endpoint": "{resql_url}/get-user-with-roles-by-id-code",
+              "endpoint": "{resql_url}/backoffice/get-user-with-roles-by-id-code",
               "post_body_struct": {
                 "userIdCode": "{$.user_id_code[0]$.userIdCode}"
               },
               "post_body_parameters": {
                 "user_id_code": {
                   "method": "post",
-                  "endpoint": "{resql_url}/insert-initial-user-or-return-existing-user-id-code",
+                  "endpoint": "{resql_url}/backoffice/insert-initial-user-or-return-existing-user-id-code",
                   "post_body_struct": {
                     "created": "$_getInstant()",
                     "userIdCode": "{$.tara_user_info$.personalCode}",

--- a/DSL.Ruuter-v1.private/account/cs-login.json
+++ b/DSL.Ruuter-v1.private/account/cs-login.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-user-with-roles",
+          "endpoint": "{resql_url}/backoffice/get-user-with-roles",
           "post_body_struct": {
             "login": "{#.login}",
             "password": "{#.password}"
@@ -93,7 +93,7 @@
         "proceed": {
           "cookies": ["customJwtCookie"],
           "method": "post",
-          "endpoint": "{resql_url}/set-customer-support-status",
+          "endpoint": "{resql_url}/backoffice/set-customer-support-status",
           "post_body_parameters": {},
           "post_body_struct": {
             "active": false,

--- a/DSL.Ruuter-v1.private/account/cs-logout.json
+++ b/DSL.Ruuter-v1.private/account/cs-logout.json
@@ -31,7 +31,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/update-chats-assignee-by-user-id",
+          "endpoint": "{resql_url}/backoffice/update-chats-assignee-by-user-id",
           "post_body_struct": {
             "userId": "{#.reflect_input#.idCode}"
           }
@@ -53,7 +53,7 @@
         "proceed": {
           "cookies": ["customJwtCookie"],
           "method": "post",
-          "endpoint": "{resql_url}/set-customer-support-status",
+          "endpoint": "{resql_url}/backoffice/set-customer-support-status",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/account/cs-set-customer-support-activity.json
+++ b/DSL.Ruuter-v1.private/account/cs-set-customer-support-activity.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-customer-support-status",
+          "endpoint": "{resql_url}/backoffice/set-customer-support-status",
           "post_body_parameters": {
             "userinfo": {
               "cookies": [

--- a/DSL.Ruuter-v1.private/account/cs-set-estimated-waiting-time.json
+++ b/DSL.Ruuter-v1.private/account/cs-set-estimated-waiting-time.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_params": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/account/cs-set-is-estimated-waiting-time-active.json
+++ b/DSL.Ruuter-v1.private/account/cs-set-is-estimated-waiting-time-active.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/account/cs-set-session-length.json
+++ b/DSL.Ruuter-v1.private/account/cs-set-session-length.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_params": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/analytics/cs-login-analytics.json
+++ b/DSL.Ruuter-v1.private/analytics/cs-login-analytics.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_json_data",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_json_data",
           "post_body_struct": {
             "data": "{$cookies$}"
           },

--- a/DSL.Ruuter-v1.private/bot/cs-get-is-bot-active.json
+++ b/DSL.Ruuter-v1.private/bot/cs-get-is-bot-active.json
@@ -11,11 +11,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_configuration_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_configuration_from_array",
           "post_body_parameters": {
             "get_configuration_value": {
               "method": "post",
-              "endpoint": "{resql_url}/get-configuration",
+              "endpoint": "{resql_url}/backoffice/get-configuration",
               "post_body_parameters": {},
               "post_body_struct": {
                 "key": "is_bot_active"

--- a/DSL.Ruuter-v1.private/bot/cs-insert-chat-and-message-when-bot-not-active.json
+++ b/DSL.Ruuter-v1.private/bot/cs-insert-chat-and-message-when-bot-not-active.json
@@ -11,11 +11,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_configuration_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_configuration_from_array",
           "post_body_parameters": {
             "get_configuration_value": {
               "method": "post",
-              "endpoint": "{resql_url}/get-configuration",
+              "endpoint": "{resql_url}/backoffice/get-configuration",
               "post_body_parameters": {
                 "check_roles": {
                   "cookies": [
@@ -85,7 +85,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-configuration",
+          "endpoint": "{resql_url}/backoffice/get-configuration",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "bot_institution_id"
@@ -103,7 +103,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat-ended-by-last-message-datetime",
+          "endpoint": "{resql_url}/backoffice/insert-chat-ended-by-last-message-datetime",
           "post_body_parameters": {
             "proceed_when_state_false": {
               "method": "post",
@@ -151,7 +151,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message-content-by-customer-support-id",
+          "endpoint": "{resql_url}/backoffice/insert-message-content-by-customer-support-id",
           "post_body_parameters": {
             "proceed_when_state_false": {
               "method": "post",
@@ -196,7 +196,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat-customer-support-by-customer-support-id",
+          "endpoint": "{resql_url}/backoffice/insert-chat-customer-support-by-customer-support-id",
           "post_body_parameters": {
             "proceed_when_state_false": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/bot/cs-set-is-bot-active.json
+++ b/DSL.Ruuter-v1.private/bot/cs-set-is-bot-active.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -98,11 +98,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_configuration_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_configuration_from_array",
           "post_body_parameters": {
             "get_configuration_value": {
               "method": "post",
-              "endpoint": "{resql_url}/get-configuration",
+              "endpoint": "{resql_url}/backoffice/get-configuration",
               "post_body_parameters": {},
               "post_body_struct": {
                 "key": "is_bot_active"

--- a/DSL.Ruuter-v1.private/chat/cs-admin-redirect-chat.json
+++ b/DSL.Ruuter-v1.private/chat/cs-admin-redirect-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_cs_claim_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_cs_claim_chat",
           "post_body_struct": {
             "id": "{#.id}",
             "customerSupportId": "{#.customerSupportId}",
@@ -38,7 +38,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.id}"
           }
@@ -86,7 +86,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_parameters": {
             "check_csa_status": {
               "post_body_parameters": {
@@ -127,7 +127,7 @@
                     }
                   },
                   "method": "post",
-                  "endpoint": "{resql_url}/get-user-by-status-array",
+                  "endpoint": "{resql_url}/backoffice/get-user-by-status-array",
                   "post_body_struct": {
                     "userIdCode": "{#.reflect_input#.customerSupportId}",
                     "statuses": "{online, idle}"
@@ -210,7 +210,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
           },
           "post_body_struct": {
@@ -246,7 +246,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-user-email-by-id-code",
+          "endpoint": "{resql_url}/backoffice/get-user-email-by-id-code",
           "post_body_struct": {
             "userIdCode": "{#.reflect_input#.customerSupportId}"
           }
@@ -273,7 +273,7 @@
                   "post_body_parameters": {
                     "get_user_profile_settings": {
                       "method": "post",
-                      "endpoint": "{resql_url}/get-user-profile-settings",
+                      "endpoint": "{resql_url}/backoffice/get-user-profile-settings",
                       "post_body_struct": {
                         "userId": "{#.reflect_input#.customerSupportId}"
                       }
@@ -293,7 +293,7 @@
                 }
               },
               "method": "post",
-              "endpoint": "{dmapper_url}/json/v2/notification_redirected_chat",
+              "endpoint": "{dmapper_url}/hbs/backoffice/notification_redirected_chat",
               "post_body_struct": {
                 "from": "{#.reflect_input#.forwardedFromCsa}",
                 "chatId": "{#.reflect_input#.id}"
@@ -324,11 +324,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_active_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-active-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.id}"
               },

--- a/DSL.Ruuter-v1.private/chat/cs-chat-add-forwarding-value.json
+++ b/DSL.Ruuter-v1.private/chat/cs-chat-add-forwarding-value.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_add_forward_value",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_add_forward_value",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "establishmentName": "{#.establishmentName}"
@@ -90,7 +90,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
           }
@@ -111,7 +111,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-establishment-value",
+          "endpoint": "{resql_url}/backoffice/get-establishment-value",
           "post_body_struct": {
             "establishmentName": "{#.reflect_input#.establishmentName}"
           }
@@ -132,7 +132,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}",
             "customerSupportId": "{#.get_not_ended_chat[0]#.customerSupportId}",

--- a/DSL.Ruuter-v1.private/chat/cs-claim-chat.json
+++ b/DSL.Ruuter-v1.private/chat/cs-claim-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_cs_claim_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_cs_claim_chat",
           "post_body_struct": {
             "id": "{#.id}",
             "customerSupportId": "{#.customerSupportId}",
@@ -38,7 +38,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.id}"
           }
@@ -86,7 +86,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -164,11 +164,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_active_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-active-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.id}"
               },

--- a/DSL.Ruuter-v1.private/chat/cs-end-chat.json
+++ b/DSL.Ruuter-v1.private/chat/cs-end-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_end_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_end_chat",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "event": "{#.event}",
@@ -34,7 +34,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
           }
@@ -123,7 +123,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/delete-message-preview",
+          "endpoint": "{resql_url}/backoffice/delete-message-preview",
           "post_body_struct": {
             "chatId": "{#.reflect_input#.chatId}"
           }
@@ -144,7 +144,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-allowed-statuses",
+          "endpoint": "{resql_url}/backoffice/get-allowed-statuses",
           "post_body_struct": {}
         },
         "response": {
@@ -163,7 +163,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_allowed_statuses",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_allowed_statuses",
           "post_body_struct": {
             "statuses": "{#.get_allowed_statuses}"
           }
@@ -226,7 +226,7 @@
             }
           },
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_struct": {
             "chatId": "{#.reflect_input#.chatId}",
             "messageId": "{#.get_message_uuid#.output}",
@@ -260,7 +260,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_struct": {
             "id": "{#.get_not_ended_chat[0]#.id}",
             "customerSupportId": "{#.get_not_ended_chat[0]#.customerSupportId}",
@@ -301,11 +301,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.chatId}"
               },

--- a/DSL.Ruuter-v1.private/chat/cs-get-all-active-chats.json
+++ b/DSL.Ruuter-v1.private/chat/cs-get-all-active-chats.json
@@ -10,7 +10,7 @@
       },
       "proceed": {
         "method": "post",
-        "endpoint": "{resql_url}/get-cs-all-active-chats",
+        "endpoint": "{resql_url}/backoffice/get-cs-all-active-chats",
         "post_body_parameters": {
           "check_roles": {
             "cookies": [

--- a/DSL.Ruuter-v1.private/chat/cs-get-all-ended-chats.json
+++ b/DSL.Ruuter-v1.private/chat/cs-get-all-ended-chats.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-cs-all-ended-chats",
+          "endpoint": "{resql_url}/backoffice/get-cs-all-ended-chats",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/chat/cs-get-all-establishments.json
+++ b/DSL.Ruuter-v1.private/chat/cs-get-all-establishments.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-all-establishments",
+          "endpoint": "{resql_url}/backoffice/get-all-establishments",
           "post_body_parameters": {
             "check_roles": {
               "cookies": [
@@ -71,7 +71,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/format-institution-connections",
+          "endpoint": "{dmapper_url}/hbs/backoffice/format-institution-connections",
           "post_body_struct": {
             "establishments": "{#.get_all_active_establishments}"
           }

--- a/DSL.Ruuter-v1.private/chat/cs-get-all-unavailable-ended-chats.json
+++ b/DSL.Ruuter-v1.private/chat/cs-get-all-unavailable-ended-chats.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-cs-all-unavailable-ended-chats",
+          "endpoint": "{resql_url}/backoffice/get-cs-all-unavailable-ended-chats",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/chat/cs-redirect-chat.json
+++ b/DSL.Ruuter-v1.private/chat/cs-redirect-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_cs_claim_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_cs_claim_chat",
           "post_body_struct": {
             "id": "{#.id}",
             "customerSupportId": "{#.customerSupportId}",
@@ -38,7 +38,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.id}"
           }
@@ -86,7 +86,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_parameters": {
             "check_csa_status": {
               "post_body_parameters": {
@@ -127,7 +127,7 @@
                     }
                   },
                   "method": "post",
-                  "endpoint": "{resql_url}/get-user-by-status-array",
+                  "endpoint": "{resql_url}/backoffice/get-user-by-status-array",
                   "post_body_struct": {
                     "userIdCode": "{#.reflect_input#.customerSupportId}",
                     "statuses": "{idle,online,offline}"
@@ -210,7 +210,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {},
           "post_body_struct": {
             "chatId": "{#.get_not_ended_chat[0]#.id}",
@@ -245,7 +245,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-user-email-by-id-code",
+          "endpoint": "{resql_url}/backoffice/get-user-email-by-id-code",
           "post_body_struct": {
             "userIdCode": "{#.reflect_input#.customerSupportId}"
           }
@@ -272,7 +272,7 @@
                   "post_body_parameters": {
                     "get_user_profile_settings": {
                       "method": "post",
-                      "endpoint": "{resql_url}/get-user-profile-settings",
+                      "endpoint": "{resql_url}/backoffice/get-user-profile-settings",
                       "post_body_struct": {
                         "userId": "{#.reflect_input#.customerSupportId}"
                       }
@@ -292,7 +292,7 @@
                 }
               },
               "method": "post",
-              "endpoint": "{dmapper_url}/json/v2/notification_redirected_chat",
+              "endpoint": "{dmapper_url}/hbs/backoffice/notification_redirected_chat",
               "post_body_struct": {
                 "from": "{#.reflect_input#.forwardedFromCsa}",
                 "chatId": "{#.reflect_input#.id}"
@@ -323,11 +323,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_active_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-active-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.id}"
               },

--- a/DSL.Ruuter-v1.private/chat/cs-remove-attached-chats.json
+++ b/DSL.Ruuter-v1.private/chat/cs-remove-attached-chats.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/remove-agent-from-chats",
+          "endpoint": "{resql_url}/backoffice/remove-agent-from-chats",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/chat/cs-unclaim-all-assigned-chats.json
+++ b/DSL.Ruuter-v1.private/chat/cs-unclaim-all-assigned-chats.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/update-chats-assignee-by-user-id",
+          "endpoint": "{resql_url}/backoffice/update-chats-assignee-by-user-id",
           "post_body_struct": {
             "userId": "{#.userId}"
           }

--- a/DSL.Ruuter-v1.private/cs-delete-configuration.json
+++ b/DSL.Ruuter-v1.private/cs-delete-configuration.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/delete-configuration",
+          "endpoint": "{resql_url}/backoffice/delete-configuration",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/cs-get-components-healthz-status.json
+++ b/DSL.Ruuter-v1.private/cs-get-components-healthz-status.json
@@ -91,7 +91,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/healthz_response",
+          "endpoint": "{dmapper_url}/hbs/backoffice/healthz_response",
           "post_body_struct": {
             "tim": "{#.get_tim_healthz_status}",
             "dmapper": "{#.get_dmapper_healthz_status}",

--- a/DSL.Ruuter-v1.private/cs-get-resql-healthz.json
+++ b/DSL.Ruuter-v1.private/cs-get-resql-healthz.json
@@ -3,7 +3,7 @@
   "destination": {
     "resql_healthz": {
       "method": "get",
-      "endpoint": "{resql_url}/healthz",
+      "endpoint": "{resql_url}/backoffice/healthz",
       "response": {
         "ok": "proceed",
         "nok": "stop"

--- a/DSL.Ruuter-v1.private/cs-post-event-message.json
+++ b/DSL.Ruuter-v1.private/cs-post-event-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_end_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_end_chat",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "event": "{#.event}",
@@ -34,7 +34,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
           }
@@ -123,7 +123,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -180,11 +180,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.chatId}"
               },

--- a/DSL.Ruuter-v1.private/greeting/cs-get-greeting-message.json
+++ b/DSL.Ruuter-v1.private/greeting/cs-get-greeting-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-greeting-message",
+          "endpoint": "{resql_url}/backoffice/get-greeting-message",
           "post_body_struct": {
           }
         },
@@ -31,7 +31,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_greeting_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_greeting_from_array",
           "post_body_struct": {
             "greetingArray": "{#.get_greeting_message}"
           }

--- a/DSL.Ruuter-v1.private/greeting/cs-set-greeting-message.json
+++ b/DSL.Ruuter-v1.private/greeting/cs-set-greeting-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/greeting/cs-set-is-greeting-active.json
+++ b/DSL.Ruuter-v1.private/greeting/cs-set-is-greeting-active.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/message/cs-get-chat-ids-matching-message-search.json
+++ b/DSL.Ruuter-v1.private/message/cs-get-chat-ids-matching-message-search.json
@@ -10,7 +10,7 @@
       },
       "proceed": {
         "method": "post",
-        "endpoint": "{resql_url}/get-chat-ids-matching-message-search",
+        "endpoint": "{resql_url}/backoffice/get-chat-ids-matching-message-search",
         "post_body_parameters": {
           "check_roles": {
             "method": "post",

--- a/DSL.Ruuter-v1.private/message/cs-get-messages-by-chat-id.json
+++ b/DSL.Ruuter-v1.private/message/cs-get-messages-by-chat-id.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-chat-messages",
+          "endpoint": "{resql_url}/backoffice/get-chat-messages",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/message/cs-get-new-messages.json
+++ b/DSL.Ruuter-v1.private/message/cs-get-new-messages.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-chat-messages-updated-after-time",
+          "endpoint": "{resql_url}/backoffice/get-chat-messages-updated-after-time",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/message/cs-post-message-with-new-event.json
+++ b/DSL.Ruuter-v1.private/message/cs-post-message-with-new-event.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_message_event",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_message_event",
           "post_body_struct": {
             "id": "{#.id}",
             "event": "{#.event}",
@@ -34,7 +34,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-message-by-id",
+          "endpoint": "{resql_url}/backoffice/get-message-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.id}"
           },
@@ -55,7 +55,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_struct": {
             "messageId": "{#.get_message_by_id[0]#.baseId}",
             "chatId": "{#.get_message_by_id[0]#.chatBaseId}",

--- a/DSL.Ruuter-v1.private/message/cs-post-message.json
+++ b/DSL.Ruuter-v1.private/message/cs-post-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_cs_post_message",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_cs_post_message",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "authorId": "{#.authorId}",
@@ -81,7 +81,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -138,7 +138,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
           }

--- a/DSL.Ruuter-v1.private/message/cs-post-redirect-request-message.json
+++ b/DSL.Ruuter-v1.private/message/cs-post-redirect-request-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_forward_message",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_forward_message",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "event": "{#.event}",
@@ -89,7 +89,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
           }
@@ -129,7 +129,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message-with-array-content",
+          "endpoint": "{resql_url}/backoffice/insert-message-with-array-content",
           "post_body_struct": {
             "chatId": "{#.reflect_input#.chatId}",
             "messageId": "{#.get_message_uuid#.output}",

--- a/DSL.Ruuter-v1.private/training/cs-get-intent.json
+++ b/DSL.Ruuter-v1.private/training/cs-get-intent.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_intent_name",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_intent_name",
           "post_body_struct": {
             "intentName": "{#.intent}"
           }
@@ -154,7 +154,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/convert_intent_data_to_object",
+          "endpoint": "{dmapper_url}/hbs/backoffice/convert_intent_data_to_object",
           "post_body_struct": {
             "intentName": "{#.reflect_input#.intentName}",
             "intentResponse": "{#.get_intent_response#.output}",

--- a/DSL.Ruuter-v1.private/training/cs-get-intents.json
+++ b/DSL.Ruuter-v1.private/training/cs-get-intents.json
@@ -131,7 +131,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_blacklisted_and_regular_intents",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_blacklisted_and_regular_intents",
           "post_body_struct": {
             "blacklistedIntentNames": "{#.get_blacklisted_intents#.output}",
             "intents": "{#.get_intents#.output}"

--- a/DSL.Ruuter-v1.private/training/cs-get-training-date.json
+++ b/DSL.Ruuter-v1.private/training/cs-get-training-date.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-configuration",
+          "endpoint": "{resql_url}/backoffice/get-configuration",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "training_date"

--- a/DSL.Ruuter-v1.private/training/cs-get-training-metadata.json
+++ b/DSL.Ruuter-v1.private/training/cs-get-training-metadata.json
@@ -138,7 +138,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_training_metadata",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_training_metadata",
           "post_body_struct": {
             "areTrainingResultsPositive": "{#.get_are_latest_training_results_positive#.output}",
             "isBotTraining": "{#.get_is_bot_training#.output}"

--- a/DSL.Ruuter-v1.private/training/cs-publish-model.json
+++ b/DSL.Ruuter-v1.private/training/cs-publish-model.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_helper_function_output",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_helper_function_output",
           "post_body_parameters": {
             "query_helper_function": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/training/cs-remove-training-date.json
+++ b/DSL.Ruuter-v1.private/training/cs-remove-training-date.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/training/cs-train-model-at.json
+++ b/DSL.Ruuter-v1.private/training/cs-train-model-at.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_training_dates",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_training_dates",
           "post_body_struct": {
             "trainingDate": "{#.trainingDate}",
             "helperFunctionInput": "{#.helperFunctionInput}"
@@ -33,7 +33,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -95,7 +95,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_helper_function_output",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_helper_function_output",
           "post_body_parameters": {
             "query_helper_function": {
               "method": "post",

--- a/DSL.Ruuter-v1.private/training/cs-train-model.json
+++ b/DSL.Ruuter-v1.private/training/cs-train-model.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/set-configuration-value",
+          "endpoint": "{resql_url}/backoffice/set-configuration-value",
           "post_body_parameters": {
             "check_roles": {
               "method": "post",
@@ -73,7 +73,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_helper_function_output",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_helper_function_output",
           "post_body_parameters": {
             "query_helper_function": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/account/cs-get-session-length.json
+++ b/DSL.Ruuter-v1.public/account/cs-get-session-length.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-configuration",
+          "endpoint": "{resql_url}/backoffice/get-configuration",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "session_length"

--- a/DSL.Ruuter-v1.public/account/cs-login.json
+++ b/DSL.Ruuter-v1.public/account/cs-login.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-user-with-roles",
+          "endpoint": "{resql_url}/backoffice/get-user-with-roles",
           "post_body_struct": {
             "login": "{#.login}",
             "password": "{#.password}"
@@ -93,7 +93,7 @@
         "proceed": {
           "cookies": ["customJwtCookie"],
           "method": "post",
-          "endpoint": "{resql_url}/set-customer-support-status",
+          "endpoint": "{resql_url}/backoffice/set-customer-support-status",
           "post_body_parameters": {},
           "post_body_struct": {
             "active": false,

--- a/DSL.Ruuter-v1.public/account/login-with-tara-jwt.json
+++ b/DSL.Ruuter-v1.public/account/login-with-tara-jwt.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_chat_id",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_chat_id",
           "post_body_struct": {
             "chatId": "{#.chatId}"
           },
@@ -32,7 +32,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-chat-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
           },
@@ -99,7 +99,7 @@
           "post_body_parameters": {
             "insert_chat_with_tara_user_info": {
               "method": "post",
-              "endpoint": "{resql_url}/insert-chat",
+              "endpoint": "{resql_url}/backoffice/insert-chat",
               "post_body_struct": {
                 "id": "{#.get_chat_by_id[0]#.id}",
                 "customerSupportId": "{#.get_chat_by_id[0]#.customerSupportId}",
@@ -163,7 +163,7 @@
     {
       "post_authentication_success_event": {
         "method": "post",
-        "endpoint": "{resql_url}/insert-message",
+        "endpoint": "{resql_url}/backoffice/insert-message",
         "post_body_struct": {
           "chatId": "{#.reflect_input#.chatId}",
           "messageId": "",

--- a/DSL.Ruuter-v1.public/bot/get-is-bot-active.json
+++ b/DSL.Ruuter-v1.public/bot/get-is-bot-active.json
@@ -11,11 +11,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_configuration_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_configuration_from_array",
           "post_body_parameters": {
             "get_configuration_value": {
               "method": "post",
-              "endpoint": "{resql_url}/get-configuration",
+              "endpoint": "{resql_url}/backoffice/get-configuration",
               "post_body_parameters": {},
               "post_body_struct": {
                 "key": "is_bot_active"

--- a/DSL.Ruuter-v1.public/bot/post-message-to-bot.json
+++ b/DSL.Ruuter-v1.public/bot/post-message-to-bot.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_post_message",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_post_message",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "authorRole": "",
@@ -39,7 +39,7 @@
           "post_body_parameters": {
             "get_configuration_value": {
               "method": "post",
-              "endpoint": "{resql_url}/get-configuration",
+              "endpoint": "{resql_url}/backoffice/get-configuration",
               "post_body_parameters": {},
               "post_body_struct": {
                 "key": "is_bot_active"
@@ -76,7 +76,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-configuration",
+          "endpoint": "{resql_url}/backoffice/get-configuration",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "bot_institution_id"
@@ -94,11 +94,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.chatId}"
               },
@@ -218,11 +218,11 @@
         },
         "regular_message": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-bot-message",
+          "endpoint": "{resql_url}/backoffice/insert-bot-message",
           "post_body_parameters": {
             "convert_bot_responses_to_messages": {
               "method": "post",
-              "endpoint": "{dmapper_url}/json/v2/bot_responses_to_messages",
+              "endpoint": "{dmapper_url}/hbs/backoffice/bot_responses_to_messages",
               "post_body_struct": {
                 "botMessages": "{#.post_client_message_to_bot}",
                 "chatId": "{#.reflect_input#.chatId}",
@@ -259,7 +259,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/remove_cs_agent_from_chat",
+          "endpoint": "{resql_url}/backoffice/remove_cs_agent_from_chat",
           "post_body_parameters": {
             "check_if_bot_unable_to_respond": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/chat/destination-forward.json
+++ b/DSL.Ruuter-v1.public/chat/destination-forward.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_destination_forward",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_destination_forward",
           "post_body_struct": {
             "messages": "{#.messages}",
             "endUserEmail": "{#.endUserEmail}",
@@ -61,7 +61,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-messages",
+          "endpoint": "{resql_url}/backoffice/insert-messages",
           "post_body_struct": {
             "messages": "{#.reflect_input#.messages}",
             "destinationChatId": "{#.get_chat_uuid#.output}"
@@ -106,7 +106,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/init-chat",
+          "endpoint": "{resql_url}/backoffice/init-chat",
           "post_body_struct": {
             "id": "{#.get_chat_uuid#.output}",
             "externalId": "{#.reflect_input#.originChatId}",
@@ -186,11 +186,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-chat-by-id",
               "post_body_struct": {
                 "id": "{#.get_chat_uuid#.output}"
               },
@@ -220,7 +220,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/format_forward_destination_response",
+          "endpoint": "{dmapper_url}/hbs/backoffice/format_forward_destination_response",
           "post_body_struct": {
             "generatedChatId": "{#.get_inserted_chat#.id}",
             "redirectJwt": "{#.generate_redirect_jwt}"

--- a/DSL.Ruuter-v1.public/chat/end-chat-locally.json
+++ b/DSL.Ruuter-v1.public/chat/end-chat-locally.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_end_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_end_chat",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "event": "{#.event}",
@@ -53,7 +53,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_parameters": {},
           "post_body_struct": {
             "id": "{#.reflect_input#.chatId}"
@@ -102,7 +102,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
             "match_user_chat_id": {
               "method": "post",
@@ -167,7 +167,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_struct": {
             "id": "{#.get_not_ended_chat[0]#.id}",
             "customerSupportId": "{#.get_not_ended_chat[0]#.customerSupportId}",

--- a/DSL.Ruuter-v1.public/chat/end-chat.json
+++ b/DSL.Ruuter-v1.public/chat/end-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_end_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_end_chat",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "event": "{#.event}",
@@ -60,7 +60,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/delete-message-preview",
+          "endpoint": "{resql_url}/backoffice/delete-message-preview",
           "post_body_struct": {
             "chatId": "{#.reflect_input#.chatId}"
           }
@@ -107,7 +107,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/chat/get-chat-by-id.json
+++ b/DSL.Ruuter-v1.public/chat/get-chat-by-id.json
@@ -46,11 +46,11 @@
         },
         "local_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "data": {
               "method": "post",
-              "endpoint": "{resql_url}/get-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-chat-by-id",
               "post_body_struct": {
                 "id": "{#.chat_info#.chatId}"
               },

--- a/DSL.Ruuter-v1.public/chat/init-chat.json
+++ b/DSL.Ruuter-v1.public/chat/init-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_init_chat",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_init_chat",
           "post_body_struct": {
             "authorRole": "{#.message#.authorRole}",
             "authorTimestamp": "{#.message#.authorTimestamp}",
@@ -212,7 +212,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_struct": {
             "chatId": "{#.get_chat_uuid#.output}",
             "messageId": "{#.get_message_uuid#.output}",
@@ -246,7 +246,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/init-chat",
+          "endpoint": "{resql_url}/backoffice/init-chat",
           "post_body_struct": {
             "id": "{#.get_chat_uuid#.output}",
             "endUserId": "{#.reflect_input#.endUserId}",
@@ -310,7 +310,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-all-available-customer-support-agents-with-email-notifications-enabled",
+          "endpoint": "{resql_url}/backoffice/get-all-available-customer-support-agents-with-email-notifications-enabled",
           "post_body_struct": {},
           "response": {
             "ok": "proceed",
@@ -336,7 +336,7 @@
             "fill_notification_new_chat": {
               "post_body_parameters": {},
               "method": "post",
-              "endpoint": "{dmapper_url}/json/v2/notification_new_chat",
+              "endpoint": "{dmapper_url}/hbs/backoffice/notification_new_chat",
               "post_body_struct": {
                 "authorTimestamp": "{#.reflect_input#.authorTimestamp}",
                 "content": "#.reflect_input#.content",
@@ -369,11 +369,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_chat_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_chat_from_array",
           "post_body_parameters": {
             "get_chat_by_id": {
               "method": "post",
-              "endpoint": "{resql_url}/get-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-chat-by-id",
               "post_body_struct": {
                 "id": "{#.get_chat_uuid#.output}"
               },

--- a/DSL.Ruuter-v1.public/chat/origin-forward.json
+++ b/DSL.Ruuter-v1.public/chat/origin-forward.json
@@ -35,7 +35,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.get_chatId#.chatId}"
           }
@@ -56,7 +56,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-redirection-messages-by-chatId",
+          "endpoint": "{resql_url}/backoffice/get-redirection-messages-by-chatId",
           "post_body_struct": {
             "chatId": "{#.get_chatId#.chatId}"
           }
@@ -77,7 +77,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_forward_to_value",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_forward_to_value",
           "post_body_struct": {
             "forwardTo": "{#.get_not_ended_chat[0]#.forwardedTo}"
           }
@@ -198,7 +198,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_parameters": {},
           "post_body_struct": {
             "id": "{#.get_chatId#.chatId}",
@@ -254,7 +254,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-chat-by-id",
           "post_body_struct": {
             "id": "{#.get_chatId#.chatId}"
           }

--- a/DSL.Ruuter-v1.public/chat/post-greeting-to-chat.json
+++ b/DSL.Ruuter-v1.public/chat/post-greeting-to-chat.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_chat_id_timestamp",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_chat_id_timestamp",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "clientTimestamp": "{#.clientTimestamp}"
@@ -68,7 +68,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
             "validate_greeting_status": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/chat/remove-chat-forwarding-value.json
+++ b/DSL.Ruuter-v1.public/chat/remove-chat-forwarding-value.json
@@ -37,7 +37,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-active-chat-by-id",
+          "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
           "post_body_struct": {
             "id": "{#.get_chatId#.chatId}"
           }
@@ -58,7 +58,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-chat",
+          "endpoint": "{resql_url}/backoffice/insert-chat",
           "post_body_struct": {
             "id": "{#.get_chatId#.chatId}",
             "customerSupportId": "{#.get_not_ended_chat[0]#.customerSupportId}",

--- a/DSL.Ruuter-v1.public/custom_jwt/custom-jwt-extend.json
+++ b/DSL.Ruuter-v1.public/custom_jwt/custom-jwt-extend.json
@@ -16,11 +16,11 @@
         "post_body_parameters": {
           "get_end_user_session_length": {
             "method": "post",
-            "endpoint": "{dmapper_url}/json/v2/return_first_configuration_from_array",
+            "endpoint": "{dmapper_url}/hbs/backoffice/return_first_configuration_from_array",
             "post_body_parameters": {
               "get_configuration_value": {
                 "method": "post",
-                "endpoint": "{resql_url}/get-configuration",
+                "endpoint": "{resql_url}/backoffice/get-configuration",
                 "post_body_parameters": {},
                 "post_body_struct": {
                   "key": "end_user_session_length"

--- a/DSL.Ruuter-v1.public/feedback/post-chat-feedback-rating.json
+++ b/DSL.Ruuter-v1.public/feedback/post-chat-feedback-rating.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_feedback",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_feedback",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "feedback": "{#.feedbackRating}"
@@ -68,7 +68,7 @@
         },
         "local_request": {
           "method": "post",
-          "endpoint": "{resql_url}/update-chat-with-feedback-rating",
+          "endpoint": "{resql_url}/backoffice/update-chat-with-feedback-rating",
           "post_body_parameters": {
             "validate_rating_value": {
               "method": "post",
@@ -92,7 +92,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/feedback/post-chat-feedback-text.json
+++ b/DSL.Ruuter-v1.public/feedback/post-chat-feedback-text.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_feedback",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_feedback",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "feedback": "{#.feedbackText}"
@@ -68,7 +68,7 @@
         },
         "local_request": {
           "method": "post",
-          "endpoint": "{resql_url}/update-chat-with-feedback-text",
+          "endpoint": "{resql_url}/backoffice/update-chat-with-feedback-text",
           "post_body_parameters": {
             "validate_text_length": {
               "method": "post",
@@ -92,7 +92,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/get-estimated-waiting-time.json
+++ b/DSL.Ruuter-v1.public/get-estimated-waiting-time.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-estimated-waiting-time",
+          "endpoint": "{resql_url}/backoffice/get-estimated-waiting-time",
           "post_body_parameters": {},
           "post_body_struct": {
             "key": "estimated_waiting_time"
@@ -33,7 +33,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_estimated_time_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_estimated_time_from_array",
           "post_body_struct": {
             "estimatedTimeArray": "{#.get_estimated_waiting_time}"
           }

--- a/DSL.Ruuter-v1.public/message/get-greeting-message.json
+++ b/DSL.Ruuter-v1.public/message/get-greeting-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-greeting-message",
+          "endpoint": "{resql_url}/backoffice/get-greeting-message",
           "post_body_struct": {
           }
         },
@@ -31,7 +31,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/return_first_greeting_from_array",
+          "endpoint": "{dmapper_url}/hbs/backoffice/return_first_greeting_from_array",
           "post_body_struct": {
             "greetingArray": "{#.get_greeting_message}"
           }

--- a/DSL.Ruuter-v1.public/message/get-messages-by-chat-id.json
+++ b/DSL.Ruuter-v1.public/message/get-messages-by-chat-id.json
@@ -46,7 +46,7 @@
         },
         "local_request": {
           "method": "post",
-          "endpoint": "{resql_url}/get-chat-messages",
+          "endpoint": "{resql_url}/backoffice/get-chat-messages",
           "post_body_struct": {
             "chatId": "{#.chat_info#.chatId}"
           },
@@ -57,7 +57,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/message/get-new-messages.json
+++ b/DSL.Ruuter-v1.public/message/get-new-messages.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_timerange",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_timerange",
           "post_body_struct": {
             "timeRangeBegin": "{#.timeRangeBegin}"
           }
@@ -67,7 +67,7 @@
         },
         "local_request": {
           "method": "post",
-          "endpoint": "{resql_url}/get-chat-messages-updated-after-time",
+          "endpoint": "{resql_url}/backoffice/get-chat-messages-updated-after-time",
           "post_body_struct": {
             "chatId": "{#.chat_info#.chatId}",
             "timeRangeBegin": "{#.reflect_input#.timeRangeBegin}"
@@ -79,7 +79,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/message/post-message-locally.json
+++ b/DSL.Ruuter-v1.public/message/post-message-locally.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_post_message",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_post_message",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "authorTimestamp": "{#.authorTimestamp}",
@@ -51,7 +51,7 @@
           "post_body_parameters": {
             "get_not_ended_chat": {
               "method": "post",
-              "endpoint": "{resql_url}/get-active-chat-by-id",
+              "endpoint": "{resql_url}/backoffice/get-active-chat-by-id",
               "post_body_struct": {
                 "id": "{#.reflect_input#.chatId}"
               },
@@ -97,7 +97,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
             "match_user_chat_id": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/message/post-message-preview.json
+++ b/DSL.Ruuter-v1.public/message/post-message-preview.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_message_preview",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_message_preview",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "content": "{#.content}"
@@ -29,7 +29,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-message-preview",
+          "endpoint": "{resql_url}/backoffice/insert-message-preview",
           "post_body_struct": {
             "chatId": "{#.reflect_input#.chatId}",
             "content": "{#.reflect_input#.content}"

--- a/DSL.Ruuter-v1.public/message/post-message-with-new-event.json
+++ b/DSL.Ruuter-v1.public/message/post-message-with-new-event.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_message_event",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_message_event",
           "post_body_struct": {
             "id": "{#.id}",
             "event": "{#.event}",
@@ -36,7 +36,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-message-by-id",
+          "endpoint": "{resql_url}/backoffice/get-message-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.id}"
           },
@@ -91,7 +91,7 @@
         "local_request": {
           "method": "post",
           "cookies": ["chatJwt"],
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_struct": {
             "messageId": "{#.get_message_by_id[0]#.baseId}",
             "chatId": "{#.get_message_by_id[0]#.chatBaseId}",
@@ -115,7 +115,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/message/post-message-with-rating.json
+++ b/DSL.Ruuter-v1.public/message/post-message-with-rating.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_message_rating",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_message_rating",
           "post_body_struct": {
             "id": "{#.id}",
             "rating": "{#.rating}"
@@ -33,7 +33,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/get-message-by-id",
+          "endpoint": "{resql_url}/backoffice/get-message-by-id",
           "post_body_struct": {
             "id": "{#.reflect_input#.id}"
           },
@@ -92,7 +92,7 @@
           "cookies": [
             "chatJwt"
           ],
-          "endpoint": "{resql_url}/insert-message",
+          "endpoint": "{resql_url}/backoffice/insert-message",
           "post_body_parameters": {
             "custom_jwt_verify": {
               "cookies": [
@@ -145,7 +145,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/message/post-message.json
+++ b/DSL.Ruuter-v1.public/message/post-message.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_post_message",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_post_message",
           "post_body_struct": {
             "chatId": "{#.message#chatId}",
             "authorTimestamp": "{#.message#.authorTimestamp}",
@@ -89,7 +89,7 @@
         },
         "external_request": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_data_arr",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_data_arr",
           "post_body_parameters": {
             "data": {
               "method": "post",

--- a/DSL.Ruuter-v1.public/services/get-weather.json
+++ b/DSL.Ruuter-v1.public/services/get-weather.json
@@ -11,7 +11,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/reflect_weather",
+          "endpoint": "{dmapper_url}/hbs/backoffice/reflect_weather",
           "post_body_struct": {
             "chatId": "{#.chatId}",
             "authorId": "{#.authorId}",
@@ -112,7 +112,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/format_weather_response",
+          "endpoint": "{dmapper_url}/hbs/backoffice/format_weather_response",
           "post_body_struct": {
             "tains": "{#.get_weather_data#.data#.get_weather_data#.entries#.entry[0]#.tains}",
             "ws10ma": "{#.get_weather_data#.data#.get_weather_data#.entries#.entry[0]#.ws10ma}",
@@ -135,11 +135,11 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{resql_url}/insert-bot-message",
+          "endpoint": "{resql_url}/backoffice/insert-bot-message",
           "post_body_parameters": {
             "convert_bot_responses_to_messages": {
               "method": "post",
-              "endpoint": "{dmapper_url}/json/v2/bot_responses_to_messages",
+              "endpoint": "{dmapper_url}/hbs/backoffice/bot_responses_to_messages",
               "post_body_struct": {
                 "botMessages": "{#.format_end_user_response}",
                 "chatId": "{#.reflect_input#.chatId}",

--- a/DSL.Ruuter-v1.public/services/sub-queries/get-location-coordinates.json
+++ b/DSL.Ruuter-v1.public/services/sub-queries/get-location-coordinates.json
@@ -29,7 +29,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/format_gazetteer_response",
+          "endpoint": "{dmapper_url}/hbs/backoffice/format_gazetteer_response",
           "post_body_struct": {
             "queryResponse": "{#.get_coordinates#.addresses}"
           },

--- a/DSL.Ruuter-v1.public/services/sub-queries/get-weather-station-id.json
+++ b/DSL.Ruuter-v1.public/services/sub-queries/get-weather-station-id.json
@@ -33,7 +33,7 @@
         },
         "proceed": {
           "method": "post",
-          "endpoint": "{dmapper_url}/json/v2/format_weather_station_response",
+          "endpoint": "{dmapper_url}/hbs/backoffice/format_weather_station_response",
           "post_body_struct": {
             "queryResponse": "{#.get_station_id#.entries#.entry}"
           },


### PR DESCRIPTION
Dmapper endpoint urls in the Ruuter-v1.private & Ruuter-v1.public were changed from {dmapper_url}/json/v2/... to {dmapper_url}/hbs/backoffice... . Resql endpoint urls in the Ruuter-v1.private & Ruuter-v1.public were changed from {resql_url}/... to {resql_url}/backoffice/...

Issue #375 