### PR TITLE
Refactor `get-cs-all-ended-chats.sql` Postgres query

### DIFF
--- a/DSL/Resql/get-cs-all-ended-chats.sql
+++ b/DSL/Resql/get-cs-all-ended-chats.sql
@@ -41,11 +41,8 @@ FROM (
            end_user_first_name, end_user_last_name, end_user_email, end_user_phone, end_user_os,
            end_user_url, status, created, updated, ended, forwarded_to_name, received_from, labels
     FROM chat
-    WHERE id IN (SELECT MAX(id) FROM chat GROUP BY base_id) AND ended IS NOT NULL AND status <> 'IDLE'
-
-    -- -- For pagination
-    -- ORDER BY created
-    -- LIMIT :limit OFFSET :offset 
+    WHERE id IN (SELECT MAX(id) FROM chat GROUP BY base_id)
+    AND ended IS NOT NULL AND status <> 'IDLE'
 ) AS c
 JOIN (
     SELECT chat_base_id, event, updated
@@ -60,7 +57,7 @@ JOIN (
     SELECT chat_base_id, content
     FROM message
     WHERE id IN (SELECT last_content_message_id FROM LatestMessages)
-) AS last_content_message ON c.base_id = w.chat_base_id
+) AS last_content_message ON c.base_id = m.chat_base_id
 JOIN (
     SELECT chat_base_id, content, created
     FROM message

--- a/DSL/Resql/get-cs-all-ended-chats.sql
+++ b/DSL/Resql/get-cs-all-ended-chats.sql
@@ -25,24 +25,26 @@ TitleVisibility AS (
   ORDER BY id
   LIMIT 1
 ),
+FulfilledMessages AS (
+  SELECT MAX(id) maxId
+  FROM message
+  WHERE event = 'contact-information-fulfilled'
+  GROUP BY chat_base_id
+),
 ContactsMessage AS (
   SELECT chat_base_id, content
   FROM message
-  WHERE id IN (
-    SELECT MAX(id)
-    FROM message
-    WHERE event = 'contact-information-fulfilled'
-    GROUP BY chat_base_id
-  )
+  JOIN FulfilledMessages ON id = maxId
+),
+MaxMessages AS (
+  SELECT MAX(id) maxId
+  FROM message
+  GROUP BY chat_base_id
 ),
 Messages AS (
   SELECT event, updated, chat_base_id
   FROM message
-  WHERE id IN (
-    SELECT MAX(id)
-    FROM message
-    GROUP BY chat_base_id
-  )
+  JOIN MaxMessages ON id = maxID
 ),
 EndedChatMessages AS (
   SELECT 

--- a/DSL/Resql/get-cs-all-ended-chats.sql
+++ b/DSL/Resql/get-cs-all-ended-chats.sql
@@ -1,22 +1,82 @@
-WITH TitleVisibility AS (
-    SELECT value
-    FROM configuration
-    WHERE NOT deleted AND key = 'is_csa_title_visible'
-    ORDER BY id DESC
-    LIMIT 1
+WITH MessageWithContent AS (
+  SELECT 
+    MAX(id) AS maxId,
+    MIN(id) AS minId
+  FROM message 
+  WHERE content <> ''
+  AND content <> 'message-read'
+  GROUP BY chat_base_id
 ),
-LatestMessages AS (
-    SELECT chat_base_id,
-           MAX(CASE WHEN event = 'contact-information-fulfilled' THEN id END) AS contacts_message_id,
-           MAX(CASE WHEN content <> '' AND content <> 'message-read' THEN id END) AS last_content_message_id,
-           MIN(CASE WHEN content <> '' AND content <> 'message-read' THEN id END) AS first_content_message_id
+FirstContentMessage AS (
+  SELECT created, chat_base_id
+  FROM message
+  JOIN MessageWithContent ON message.id = MessageWithContent.minId
+),
+LastContentMessage AS (
+  SELECT content, chat_base_id
+  FROM message
+  JOIN MessageWithContent ON message.id = MessageWithContent.maxId
+),
+TitleVisibility AS (
+  SELECT value
+  FROM configuration
+  WHERE key = 'is_csa_title_visible' 
+  AND NOT deleted
+  ORDER BY id
+  LIMIT 1
+),
+ContactsMessage AS (
+  SELECT chat_base_id, content
+  FROM message
+  WHERE id IN (
+    SELECT MAX(id)
+    FROM message
+    WHERE event = 'contact-information-fulfilled'
+    GROUP BY chat_base_id
+  )
+),
+Messages AS (
+  SELECT event, updated, chat_base_id
+  FROM message
+  WHERE id IN (
+    SELECT MAX(id)
     FROM message
     GROUP BY chat_base_id
+  )
+),
+EndedChatMessages AS (
+  SELECT 
+    base_id,
+    customer_support_id,
+    customer_support_display_name,
+    csa_title,
+    end_user_id,
+    end_user_first_name,
+    end_user_last_name,
+    end_user_email,
+    end_user_phone,
+    end_user_os,
+    end_user_url,
+    status,
+    updated,
+    ended,
+    forwarded_to_name,
+    received_from,
+    labels,
+    created
+  FROM chat
+  WHERE id IN (
+    SELECT MAX(id)
+    FROM chat
+    GROUP BY base_id
+  )
+  AND ended IS NOT NULL
+  AND status <> 'IDLE'
 )
 SELECT c.base_id AS id,
        c.customer_support_id,
        c.customer_support_display_name,
-       CASE WHEN conf.value = 'true' THEN c.csa_title ELSE '' END AS csa_title,
+       (CASE WHEN TitleVisibility.value = 'true' THEN c.csa_title ELSE '' END) AS csa_title,
        c.end_user_id,
        c.end_user_first_name,
        c.end_user_last_name,
@@ -25,50 +85,24 @@ SELECT c.base_id AS id,
        c.end_user_os,
        c.end_user_url,
        c.status,
-       first_message.created AS created,
+       FirstContentMessage.created,
        c.updated,
        c.ended,
        c.forwarded_to_name,
        c.received_from,
        c.labels,
        s.comment,
-       last_content_message.content AS last_message,
-       LOWER(m.event) AS last_message_event,
-       contacts_message.content AS contacts_message,
+       LastContentMessage.content AS last_message,
+       (CASE WHEN m.event = '' THEN NULL ELSE LOWER(m.event) END) as last_message_event,
+       ContactsMessage.content AS ContactsMessage,
        m.updated AS last_message_timestamp
-FROM (
-    SELECT base_id, customer_support_id, customer_support_display_name, csa_title, end_user_id,
-           end_user_first_name, end_user_last_name, end_user_email, end_user_phone, end_user_os,
-           end_user_url, status, created, updated, ended, forwarded_to_name, received_from, labels
-    FROM chat
-    WHERE id IN (SELECT MAX(id) FROM chat GROUP BY base_id)
-    AND ended IS NOT NULL AND status <> 'IDLE'
-) AS c
-JOIN (
-    SELECT chat_base_id, event, updated
-    FROM message
-    WHERE id IN (SELECT MAX(id) FROM message GROUP BY chat_base_id)
-) AS m ON c.base_id = m.chat_base_id
-LEFT JOIN (
-    SELECT chat_id, comment
-    FROM chat_history_comments
-) AS s ON s.chat_id = m.chat_base_id
-JOIN (
-    SELECT chat_base_id, content
-    FROM message
-    WHERE id IN (SELECT last_content_message_id FROM LatestMessages)
-) AS last_content_message ON c.base_id = m.chat_base_id
-JOIN (
-    SELECT chat_base_id, content, created
-    FROM message
-    WHERE id IN (SELECT first_content_message_id FROM LatestMessages)
-) AS first_message ON c.base_id = first_message.chat_base_id
-LEFT JOIN (
-    SELECT chat_base_id, content
-    FROM message
-    WHERE id IN (SELECT contacts_message_id FROM LatestMessages)
-) AS contacts_message ON c.base_id = contacts_message.chat_base_id
-CROSS JOIN TitleVisibility AS conf
+FROM EndedChatMessages AS c
+JOIN Messages AS m ON c.base_id = m.chat_base_id
+LEFT JOIN chat_history_comments AS s ON s.chat_id =  m.chat_base_id
+JOIN LastContentMessage ON c.base_id = LastContentMessage.chat_base_id
+JOIN FirstContentMessage ON c.base_id = FirstContentMessage.chat_base_id
+LEFT JOIN ContactsMessage ON ContactsMessage.chat_base_id = c.base_id
+CROSS JOIN TitleVisibility
 WHERE c.created::date BETWEEN :start::date AND :end::date
-ORDER BY c.created ASC
-LIMIT 100;
+ORDER BY created ASC
+LIMIT :limit;

--- a/DSL/Resql/get-cs-all-ended-chats.sql
+++ b/DSL/Resql/get-cs-all-ended-chats.sql
@@ -22,7 +22,7 @@ TitleVisibility AS (
   FROM configuration
   WHERE key = 'is_csa_title_visible' 
   AND NOT deleted
-  ORDER BY id
+  ORDER BY id DESC
   LIMIT 1
 ),
 FulfilledMessages AS (

--- a/DSL/Ruuter.private/DSL/POST/agents/chats/ended.yml
+++ b/DSL/Ruuter.private/DSL/POST/agents/chats/ended.yml
@@ -27,6 +27,7 @@ getEndedChats:
     body:
       start: ${startDate}
       end: ${endDate}  
+      limit: 100
   result: res
 
 returnSuccess:


### PR DESCRIPTION
Related to:
- https://github.com/buerokratt/Buerokratt-Chatbot/issues/565

In this PR:
- CTE has been used instead of subqueries to improve the performance.
- Default LIMIT of 100 (with ordering) has been set to prevent overwhelming result.