### PR TITLE
Refactor `get-cs-all-pending-chats.sql` Postgres query

### DIFF
--- a/DSL/Resql/get-cs-all-pending-chats.sql
+++ b/DSL/Resql/get-cs-all-pending-chats.sql
@@ -1,33 +1,73 @@
-WITH max_message AS (
-  SELECT MAX(id) AS id, chat_base_id
-  FROM message
-  WHERE event <> 'rating'
-    AND event <> 'requested-chat-forward'
-  GROUP BY chat_base_id
-),
-max_content_message AS (
-  SELECT MAX(id) AS id, chat_base_id
-  FROM message
-  WHERE event <> 'rating'
-    AND event <> 'requested-chat-forward'
-    AND content <> ''
-    AND content <> 'message-read'
-  GROUP BY chat_base_id
-),
-TitleVisibility AS (
+WITH TitleVisibility AS (
   SELECT value
   FROM configuration
   WHERE KEY = 'is_csa_title_visible' AND NOT deleted
   ORDER BY id DESC
   LIMIT 1
+),
+YYYY AS (
+    SELECT MAX(id) maxId
+    FROM message
+    WHERE event <> 'rating'
+    AND event <> 'requested-chat-forward'
+    AND content <> ''
+    AND content <> 'message-read'
+    GROUP BY chat_base_id
+),
+LastContentMessage AS (
+  SELECT content, chat_base_id
+  FROM message
+  JOIN YYYY ON id = maxId
+),
+Q23232323 AS (
+  SELECT MAX(id) maxId
+  FROM message
+  WHERE event <> 'rating'
+  AND event <> 'requested-chat-forward'
+  GROUP BY chat_base_id
+),
+Messages AS (
+  SELECT *
+  FROM message
+  JOIN Q23232323 ON id = maxId
+),
+MaxChats AS (
+  SELECT MAX(id) maxId
+  FROM chat
+  GROUP BY base_id
+),
+Q11111 AS (
+  SELECT *
+  FROM chat
+  JOIN MaxChats ON id = maxId
+  WHERE status = 'IDLE'
+),
+MessagesWithEvent AS (
+  SELECT MAX(id) maxId
+  FROM message
+  WHERE event <> ''
+  GROUP BY chat_base_id
+),
+LastMessageEvent AS (
+  SELECT event, chat_base_id
+  FROM message
+  JOIN MessagesWithEvent ON id = maxId
+),
+FulfilledMessage AS (
+  SELECT MAX(id) maxId
+  FROM message
+  WHERE event = 'contact-information-fulfilled'
+  GROUP BY chat_base_id
+)
+MessageContentXXXXXX AS (
+  SELECT content, chat_base_id
+  FROM message
+  JOIN FulfilledMessage ON id = maxId
 )
 SELECT c.base_id AS id,
        c.customer_support_id,
        c.customer_support_display_name,
-       (CASE
-            WHEN TitleVisibility.value = 'true' THEN c.csa_title
-            ELSE ''
-        END) AS csa_title,
+       (CASE WHEN TitleVisibility.value = 'true' THEN c.csa_title ELSE '' END) AS csa_title,
        c.end_user_id,
        c.end_user_first_name,
        c.end_user_last_name,
@@ -44,18 +84,15 @@ SELECT c.base_id AS id,
        c.forwarded_to_name,
        c.received_from,
        c.received_from_name,
-       last_content_message.content AS last_message,
-       contacts_message.content AS contacts_message,
+       LastContentMessage.content AS last_message,
+       MessageContentXXXXXX.content AS contacts_message,
        m.updated AS last_message_timestamp,
-       last_message_event.event AS last_message_event
-FROM chat AS c
-JOIN message AS m ON c.base_id = m.chat_base_id
-JOIN max_message ON m.id = max_message.id
-JOIN message AS last_content_message ON c.base_id = last_content_message.chat_base_id
-JOIN max_content_message ON last_content_message.id = max_content_message.id
-LEFT JOIN message AS contacts_message ON c.base_id = contacts_message.chat_base_id AND contacts_message.event = 'contact-information-fulfilled'
-LEFT JOIN message AS last_message_event ON c.base_id = last_message_event.chat_base_id AND last_message_event.event <> ''
+       LastMessageEvent.event AS last_message_event
+FROM Q11111 AS c
+LEFT JOIN Messages AS m ON c.base_id = m.chat_base_id
+LEFT JOIN LastContentMessage ON c.base_id = LastContentMessage.chat_base_id
+LEFT JOIN LastMessageEvent ON LastMessageEvent.chat_base_id = c.base_id
+LEFT JOIN MessageContentXXXXXX ON MessageContentXXXXXX.chat_base_id = c.base_id
 CROSS JOIN TitleVisibility
-WHERE c.status = 'IDLE'
-ORDER BY c.created ASC
-LIMIT 100;
+ORDER BY created ASC
+LIMIT :limit;

--- a/DSL/Ruuter.private/DSL/GET/agents/chats/pending.yml
+++ b/DSL/Ruuter.private/DSL/GET/agents/chats/pending.yml
@@ -11,6 +11,8 @@ getPendingChats:
   call: http.post
   args:
     url: "[#CHATBOT_RESQL]/get-cs-all-pending-chats"
+    body:
+      limit: 100
   result: res
 
 return_result:


### PR DESCRIPTION
Related to:
- https://github.com/buerokratt/Buerokratt-Chatbot/issues/566

In this PR:
- CTE has been used instead of subqueries to improve the performance.
- Default LIMIT of 100 (with ordering) has been set to prevent overwhelming result.