### PR TITLE
BUG FIX - Chat history in reverse chronological order by default

### DIFF
--- a/DSL/Resql/get-cs-all-ended-chats.sql
+++ b/DSL/Resql/get-cs-all-ended-chats.sql
@@ -117,5 +117,5 @@ JOIN LastContentMessage ON c.base_id = LastContentMessage.chat_base_id
 JOIN FirstContentMessage ON c.base_id = FirstContentMessage.chat_base_id
 LEFT JOIN ContactsMessage ON ContactsMessage.chat_base_id = c.base_id
 CROSS JOIN TitleVisibility
-ORDER BY created ASC
+ORDER BY created DESC
 LIMIT :limit;


### PR DESCRIPTION
Related to:
- https://github.com/buerokratt/Buerokratt-Chatbot/issues/577