### PR TITLE
Disable password login endpoint

### DIFF
--- a/DSL/Ruuter.public/DSL/POST/auth/login.yml
+++ b/DSL/Ruuter.public/DSL/POST/auth/login.yml
@@ -15,6 +15,16 @@ declaration:
         type: string
         description: "Body field 'password'"
 
+getIsPasswordAuthEnabled:
+  assign:
+    isPasswordAuthEnabled: "[#PASSWORD_AUTH_ENABLED]"
+
+checkPasswordLoginEnabled:
+  switch:
+    - condition: ${isPasswordAuthEnabled === true || isPasswordAuthEnabled.toLowerCase() === "true"}
+      next: extractRequestData
+  next: return_password_login_disabled
+
 extractRequestData:
   assign:
     login: ${incoming.body.login}
@@ -88,4 +98,9 @@ return_value:
 return_user_not_found:
   status: 400
   return: "User Not Found"
+  next: end
+
+return_password_login_disabled:
+  status: 400
+  return: "Password login is disabled"
   next: end

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ This repo will primarily contain:
 Currently, Header and Main Navigation used as external components, they are defined as dependency in package.json
 
 ```
- "@buerokrat-ria/header": "^0.0.1"
- "@buerokrat-ria/menu": "^0.0.1"
- "@buerokrat-ria/styles": "^0.0.1"
+ "@buerokratt-ria/header": "^0.0.1"
+ "@buerokratt-ria/menu": "^0.0.1"
+ "@buerokratt-ria/styles": "^0.0.1"
 ```
 
 ### Notes

--- a/constants.ini
+++ b/constants.ini
@@ -17,3 +17,4 @@ CHATBOT_EXTERNAL_KEY=local-key
 DOMAIN=localhost
 TRAINING_RESQL=http://resql-training:8083
 SERVICE_RUUTER_PUBLIC=http://ruuter-public:8086
+PASSWORD_AUTH_ENABLED=TRUE


### PR DESCRIPTION
Related to: 
- https://github.com/buerokratt/Buerokratt-Chatbot/issues/724

## Importent notes:
- Add the variable `PASSWORD_AUTH_ENABLED` to constants.ini with `true` or `false` values to enable/disable password login.
- `PASSWORD_AUTH_ENABLED` should be added to Authentication-layer [env-config.js](https://github.com/buerokratt/Authentication-Layer/blob/3d510c3d1694fde54c10b54892ca35bf4a1646be/public/env-config.js#L9) as well.