### PR TITLE
728 Get rid of doc references and extraneous spaces in the end of sentences

### DIFF
--- a/DSL/Ruuter.public/DSL/POST/internal/external-bot.yml
+++ b/DSL/Ruuter.public/DSL/POST/internal/external-bot.yml
@@ -59,7 +59,7 @@ assign_value:
   assign:
     correct_value:
       - recipient_id: ${incoming.body.sender}
-        text: ${test.response.body.choices[0].message.content.replace(/\n/g," ").replace(/%/g," protsenti")}
+        text: ${test.response.body.choices[0].message.content.replace(/\n/g," ").replace(/%/g," protsenti").replace(/\[doc\d+\]\w+/g, "").replace(" \. ", ". ")}
   next: return_value
 
 return_value:


### PR DESCRIPTION
Added the regular expressions  to: 
* remove the [docN] from the response
* removed the extra space between the "." and last letter when sentence ends.