### PR TITLE
#826  [BUG] Rollback of SQL to update user settings 

### DIFF
--- a/DSL/Resql/set-user-profile-settings.sql
+++ b/DSL/Resql/set-user-profile-settings.sql
@@ -4,4 +4,11 @@ INSERT INTO user_profile_settings (user_id, forwarded_chat_popup_notifications,
                                    new_chat_email_notifications, use_autocorrect)
 VALUES
     (:userId, :forwardedChatPopupNotifications, :forwardedChatSoundNotifications, :forwardedChatEmailNotifications,
-    :newChatPopupNotifications, :newChatSoundNotifications, :newChatEmailNotifications, :useAutocorrect);
+    :newChatPopupNotifications, :newChatSoundNotifications, :newChatEmailNotifications, :useAutocorrect)
+ON CONFLICT(user_id) DO UPDATE SET forwarded_chat_popup_notifications = :forwardedChatPopupNotifications,
+                                   forwarded_chat_sound_notifications = :forwardedChatSoundNotifications,
+                                   forwarded_chat_email_notifications = :forwardedChatEmailNotifications,
+                                   new_chat_popup_notifications = :newChatPopupNotifications,
+                                   new_chat_sound_notifications = :newChatSoundNotifications,
+                                   new_chat_email_notifications = :newChatEmailNotifications,
+                                   use_autocorrect = :useAutocorrect;


### PR DESCRIPTION
Partial rollback of c9c9c5abd4284b91e141281091d30cc90ef19916
(Refactor all Postgres Chatbot's queries to replace UPDATE queries with INSERT and SELECT (#605) )