### PR TITLE
Update external-bot.yml regex

### DIFF
--- a/DSL/Ruuter.public/DSL/POST/internal/external-bot.yml
+++ b/DSL/Ruuter.public/DSL/POST/internal/external-bot.yml
@@ -59,7 +59,7 @@ assign_value:
   assign:
     correct_value:
       - recipient_id: ${incoming.body.sender}
-        text: ${test.response.body.choices[0].message.content.replace(/\n/g," ").replace(/%/g," protsenti").replace(/\[doc\d+\]\s*,?\s*/g, "").replace(" \. ", ". ")}
+        text: ${test.response.body.choices[0].message.content.replace(/\n/g," ").replace(/%/g," protsenti").replace(/\s*\[doc\s*\d+\]\s*,?\s*/g,"").replace(" \. ", ". ")}
   next: return_value
 
 return_value:


### PR DESCRIPTION
Improved the regex to encompass variety of LLM doc additions. It should also remove the "'3]" and others at the end of the sentence.