### PR TITLE
[BUG] On-Hold chat buttons do not fit the screen. (#817)

### DIFF
--- a/GUI/src/components/Chat/Chat.scss
+++ b/GUI/src/components/Chat/Chat.scss
@@ -56,6 +56,7 @@
     left: 5px;
     top: 0px;
     bottom: 8px;
+    flex-flow: wrap;
 
     .btn {
       padding-left: 20px;


### PR DESCRIPTION
 - added flex wrap to make buttons fit chat's toolbar