### PR TITLE
Hot Fix: Message Content Limit

### DIFF
--- a/DSL/Liquibase/changelog/20240621171002-remove_message_content_limit.sql
+++ b/DSL/Liquibase/changelog/20240621171002-remove_message_content_limit.sql
@@ -1,6 +1,6 @@
 -- liquibase formatted sql
 -- changeset 1AhmedYasser:20240621171002
 
-DROP INDEX idx_message_content;
+DROP INDEX IF EXISTS idx_message_content;
 ALTER TABLE message ALTER COLUMN content TYPE TEXT;
-CREATE INDEX idx_message_content_hash ON message USING btree (MD5(content));
+CREATE INDEX IF NOT EXISTS idx_message_content_hash ON message USING btree (MD5(content));

--- a/DSL/Liquibase/changelog/20240621171002-remove_message_content_limit.sql
+++ b/DSL/Liquibase/changelog/20240621171002-remove_message_content_limit.sql
@@ -1,0 +1,6 @@
+-- liquibase formatted sql
+-- changeset 1AhmedYasser:20240621171002
+
+DROP INDEX idx_message_content;
+ALTER TABLE message ALTER COLUMN content TYPE TEXT;
+CREATE INDEX idx_message_content_hash ON message USING btree (MD5(content));


### PR DESCRIPTION
- Removed idx_message_content index
- Changed message content column type to text instead of varchar to remove limit
- Created idx_message_content_hash on content to better index large content