### PR TITLE
Hot-Fix: Markdown open links in new tab

### DIFF
--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -5,7 +5,7 @@ const Markdownify = (props: { message: string | undefined }): JSX.Element => {
 
   return (
     <div>
-      <Markdown target="_blank" options={{ enforceAtxHeadings: true }}>
+      <Markdown options={{ enforceAtxHeadings: true, overrides: { a: { props: { target: "_blank" } } } }}>
         {message ?? ''}
       </Markdown>
     </div>


### PR DESCRIPTION
- Fixed Open links in new tab from within 'markdown-to-jsx' package