### PR TITLE
932 Fixing chat selection

### DIFF
--- a/DSL/Resql/get-cs-all-ended-chats.sql
+++ b/DSL/Resql/get-cs-all-ended-chats.sql
@@ -1,71 +1,71 @@
 WITH MaxChatHistoryComments AS (
-  SELECT MAX(id) AS maxId
-  FROM chat_history_comments
-  GROUP BY chat_id
+    SELECT MAX(id) AS maxId
+    FROM chat_history_comments
+    GROUP BY chat_id
 ),
-ChatHistoryComments AS (
-  SELECT comment, chat_id
-  FROM chat_history_comments
-  JOIN MaxChatHistoryComments ON id = maxId
-),
-MessageWithContent AS (
-  SELECT 
-    MAX(id) AS maxId,
-    MIN(id) AS minId
-  FROM message 
-  WHERE content <> ''
-  AND content <> 'message-read'
-  GROUP BY chat_base_id
-),
-FirstContentMessage AS (
-  SELECT created, chat_base_id
-  FROM message
-  JOIN MessageWithContent ON message.id = MessageWithContent.minId
-),
-LastContentMessage AS (
-  SELECT content, chat_base_id
-  FROM message
-  JOIN MessageWithContent ON message.id = MessageWithContent.maxId
-),
-TitleVisibility AS (
-  SELECT value
-  FROM configuration
-  WHERE key = 'is_csa_title_visible' 
-  AND NOT deleted
-  ORDER BY id DESC
-  LIMIT 1
-),
-FulfilledMessages AS (
-  SELECT MAX(id) AS maxId
-  FROM message
-  WHERE event = 'contact-information-fulfilled'
-  GROUP BY chat_base_id
-),
-ContactsMessage AS (
-  SELECT chat_base_id, content
-  FROM message
-  JOIN FulfilledMessages ON id = maxId
-),
-MaxMessages AS (
-  SELECT MAX(id) AS maxId
-  FROM message
-  GROUP BY chat_base_id
-),
-Messages AS (
-  SELECT event, updated, chat_base_id
-  FROM message
-  JOIN MaxMessages ON id = maxID
-),
-MaxChats AS (
-  SELECT MAX(id) AS maxId
-  FROM chat
-  WHERE ended IS NOT NULL
+     ChatHistoryComments AS (
+         SELECT comment, chat_id
+         FROM chat_history_comments
+                  JOIN MaxChatHistoryComments ON id = maxId
+     ),
+     MessageWithContent AS (
+         SELECT
+             MAX(id) AS maxId,
+             MIN(id) AS minId
+         FROM message
+         WHERE content <> ''
+           AND content <> 'message-read'
+         GROUP BY chat_base_id
+     ),
+     FirstContentMessage AS (
+         SELECT created, chat_base_id
+         FROM message
+                  JOIN MessageWithContent ON message.id = MessageWithContent.minId
+     ),
+     LastContentMessage AS (
+         SELECT content, chat_base_id
+         FROM message
+                  JOIN MessageWithContent ON message.id = MessageWithContent.maxId
+     ),
+     TitleVisibility AS (
+         SELECT value
+         FROM configuration
+         WHERE key = 'is_csa_title_visible'
+    AND NOT deleted
+ORDER BY id DESC
+    LIMIT 1
+    ),
+    FulfilledMessages AS (
+SELECT MAX(id) AS maxId
+FROM message
+WHERE event = 'contact-information-fulfilled'
+GROUP BY chat_base_id
+    ),
+    ContactsMessage AS (
+SELECT chat_base_id, content
+FROM message
+    JOIN FulfilledMessages ON id = maxId
+    ),
+    MaxMessages AS (
+SELECT MAX(id) AS maxId
+FROM message
+GROUP BY chat_base_id
+    ),
+    Messages AS (
+SELECT event, updated, chat_base_id
+FROM message
+    JOIN MaxMessages ON id = maxID
+    ),
+    MaxChats AS (
+SELECT MAX(id) AS maxId
+FROM chat
+WHERE ended IS NOT NULL
   AND status <> 'IDLE'
-  AND created::date BETWEEN :start::date AND :end::date
-  GROUP BY base_id
-),
-EndedChatMessages AS (
-  SELECT 
+  AND ended::date BETWEEN :start::date AND :end::date
+GROUP BY base_id
+    ),
+    EndedChatMessages AS (
+SELECT
     base_id,
     customer_support_id,
     customer_support_display_name,
@@ -86,30 +86,30 @@ EndedChatMessages AS (
     created,
     feedback_text,
     feedback_rating
-  FROM chat
-  RIGHT JOIN MaxChats ON id = maxId
-),
-RatedChats AS (
-	SELECT MAX(feedback_rating) AS rating
-  FROM chat
-  WHERE feedback_rating IS NOT NULL
-  GROUP BY base_id
-),
-RatedChatsCount AS (
-	SELECT COUNT(rating) AS total FROM RatedChats
-),
-Promoters AS (
-	SELECT COUNT(rating) AS p FROM RatedChats WHERE rating >= 9
-),
-Detractors AS (
-	SELECT COUNT(rating) AS d FROM RatedChats WHERE rating <= 6
-), 
-NPS AS (
-  SELECT ROUND(((p / (GREATEST(total, 1) * 1.0)) - (d / (GREATEST(total, 1) * 1.0))) * 100.0, 2) AS nps
-  FROM RatedChatsCount
-  CROSS JOIN Promoters
-  CROSS JOIN Detractors
-)
+FROM chat
+    RIGHT JOIN MaxChats ON id = maxId
+    ),
+    RatedChats AS (
+SELECT MAX(feedback_rating) AS rating
+FROM chat
+WHERE feedback_rating IS NOT NULL
+GROUP BY base_id
+    ),
+    RatedChatsCount AS (
+SELECT COUNT(rating) AS total FROM RatedChats
+    ),
+    Promoters AS (
+SELECT COUNT(rating) AS p FROM RatedChats WHERE rating >= 9
+    ),
+    Detractors AS (
+SELECT COUNT(rating) AS d FROM RatedChats WHERE rating <= 6
+    ),
+    NPS AS (
+SELECT ROUND(((p / (GREATEST(total, 1) * 1.0)) - (d / (GREATEST(total, 1) * 1.0))) * 100.0, 2) AS nps
+FROM RatedChatsCount
+    CROSS JOIN Promoters
+    CROSS JOIN Detractors
+    )
 SELECT c.base_id AS id,
        c.customer_support_id,
        c.customer_support_display_name,
@@ -138,51 +138,51 @@ SELECT c.base_id AS id,
        nps,
        CEIL(COUNT(*) OVER() / :page_size::DECIMAL) AS total_pages
 FROM EndedChatMessages AS c
-JOIN Messages AS m ON c.base_id = m.chat_base_id
-LEFT JOIN ChatHistoryComments AS s ON s.chat_id =  m.chat_base_id
-JOIN LastContentMessage ON c.base_id = LastContentMessage.chat_base_id
-JOIN FirstContentMessage ON c.base_id = FirstContentMessage.chat_base_id
-LEFT JOIN ContactsMessage ON ContactsMessage.chat_base_id = c.base_id
-CROSS JOIN TitleVisibility
-CROSS JOIN NPS
+         JOIN Messages AS m ON c.base_id = m.chat_base_id
+         LEFT JOIN ChatHistoryComments AS s ON s.chat_id =  m.chat_base_id
+         JOIN LastContentMessage ON c.base_id = LastContentMessage.chat_base_id
+         JOIN FirstContentMessage ON c.base_id = FirstContentMessage.chat_base_id
+         LEFT JOIN ContactsMessage ON ContactsMessage.chat_base_id = c.base_id
+         CROSS JOIN TitleVisibility
+         CROSS JOIN NPS
 WHERE (
-  :search IS NULL OR
-  :search = '' OR
-  LOWER(c.customer_support_display_name) LIKE LOWER('%' || :search || '%') OR
-  LOWER(c.end_user_first_name) LIKE LOWER('%' || :search || '%') OR
-  LOWER(ContactsMessage.content) LIKE LOWER('%' || :search || '%') OR
-  LOWER(s.comment) LIKE LOWER('%' || :search || '%') OR
-  LOWER(c.status) LIKE LOWER('%' || :search || '%') OR
-  LOWER(m.event) LIKE LOWER('%' || :search || '%') OR
-  LOWER(c.base_id) LIKE LOWER('%' || :search || '%') OR
-  TO_CHAR(FirstContentMessage.created, 'DD.MM.YYYY HH24:MI:SS') LIKE '%' || :search || '%' OR
-  TO_CHAR(c.ended, 'DD.MM.YYYY HH24:MI:SS') LIKE '%' || :search || '%' OR
-  EXISTS (
-    SELECT 1
-    FROM message AS msg
-    WHERE msg.chat_base_id = c.base_id
-    AND LOWER(msg.content) LIKE LOWER('%' || :search || '%')
-  )
-)
-ORDER BY 
-   CASE WHEN :sorting = 'created asc' THEN FirstContentMessage.created END ASC,
-   CASE WHEN :sorting = 'created desc' THEN FirstContentMessage.created END DESC,
-   CASE WHEN :sorting = 'ended asc' THEN c.ended END ASC,
-   CASE WHEN :sorting = 'ended desc' THEN c.ended END DESC,
-   CASE WHEN :sorting = 'customerSupportDisplayName asc' THEN c.customer_support_display_name END ASC,
-   CASE WHEN :sorting = 'customerSupportDisplayName desc' THEN c.customer_support_display_name END DESC,
-   CASE WHEN :sorting = 'endUserName asc' THEN c.end_user_first_name END ASC,
-   CASE WHEN :sorting = 'endUserName desc' THEN c.end_user_first_name END DESC,
-   CASE WHEN :sorting = 'endUserId asc' THEN c.end_user_id END ASC,
-   CASE WHEN :sorting = 'endUserId desc' THEN c.end_user_id END desc,
-   CASE WHEN :sorting = 'contactsMessage asc' THEN ContactsMessage.content END ASC,
-   CASE WHEN :sorting = 'contactsMessage desc' THEN ContactsMessage.content END DESC,
-   CASE WHEN :sorting = 'comment asc' THEN s.comment END ASC,
-   CASE WHEN :sorting = 'comment desc' THEN s.comment END DESC,
-   CASE WHEN :sorting = 'labels asc' THEN c.labels END ASC,
-   CASE WHEN :sorting = 'labels desc' THEN c.labels END DESC,
-   CASE WHEN :sorting = 'status asc' THEN c.status END ASC,
-   CASE WHEN :sorting = 'status desc' THEN c.status END DESC,
-   CASE WHEN :sorting = 'id asc' THEN c.base_id END ASC,
-   CASE WHEN :sorting = 'id desc' THEN c.base_id END DESC
+          :search IS NULL OR
+          :search = '' OR
+          LOWER(c.customer_support_display_name) LIKE LOWER('%' || :search || '%') OR
+          LOWER(c.end_user_first_name) LIKE LOWER('%' || :search || '%') OR
+          LOWER(ContactsMessage.content) LIKE LOWER('%' || :search || '%') OR
+          LOWER(s.comment) LIKE LOWER('%' || :search || '%') OR
+          LOWER(c.status) LIKE LOWER('%' || :search || '%') OR
+          LOWER(m.event) LIKE LOWER('%' || :search || '%') OR
+          LOWER(c.base_id) LIKE LOWER('%' || :search || '%') OR
+          TO_CHAR(FirstContentMessage.created, 'DD.MM.YYYY HH24:MI:SS') LIKE '%' || :search || '%' OR
+          TO_CHAR(c.ended, 'DD.MM.YYYY HH24:MI:SS') LIKE '%' || :search || '%' OR
+          EXISTS (
+              SELECT 1
+              FROM message AS msg
+              WHERE msg.chat_base_id = c.base_id
+                AND LOWER(msg.content) LIKE LOWER('%' || :search || '%')
+          )
+          )
+ORDER BY
+    CASE WHEN :sorting = 'created asc' THEN FirstContentMessage.created END ASC,
+    CASE WHEN :sorting = 'created desc' THEN FirstContentMessage.created END DESC,
+    CASE WHEN :sorting = 'ended asc' THEN c.ended END ASC,
+    CASE WHEN :sorting = 'ended desc' THEN c.ended END DESC,
+    CASE WHEN :sorting = 'customerSupportDisplayName asc' THEN c.customer_support_display_name END ASC,
+    CASE WHEN :sorting = 'customerSupportDisplayName desc' THEN c.customer_support_display_name END DESC,
+    CASE WHEN :sorting = 'endUserName asc' THEN c.end_user_first_name END ASC,
+    CASE WHEN :sorting = 'endUserName desc' THEN c.end_user_first_name END DESC,
+    CASE WHEN :sorting = 'endUserId asc' THEN c.end_user_id END ASC,
+    CASE WHEN :sorting = 'endUserId desc' THEN c.end_user_id END desc,
+    CASE WHEN :sorting = 'contactsMessage asc' THEN ContactsMessage.content END ASC,
+    CASE WHEN :sorting = 'contactsMessage desc' THEN ContactsMessage.content END DESC,
+    CASE WHEN :sorting = 'comment asc' THEN s.comment END ASC,
+    CASE WHEN :sorting = 'comment desc' THEN s.comment END DESC,
+    CASE WHEN :sorting = 'labels asc' THEN c.labels END ASC,
+    CASE WHEN :sorting = 'labels desc' THEN c.labels END DESC,
+    CASE WHEN :sorting = 'status asc' THEN c.status END ASC,
+    CASE WHEN :sorting = 'status desc' THEN c.status END DESC,
+    CASE WHEN :sorting = 'id asc' THEN c.base_id END ASC,
+    CASE WHEN :sorting = 'id desc' THEN c.base_id END DESC
 OFFSET ((GREATEST(:page, 1) - 1) * :page_size) LIMIT :page_size;

--- a/GUI/src/pages/Chat/ChatHistory/index.tsx
+++ b/GUI/src/pages/Chat/ChatHistory/index.tsx
@@ -486,8 +486,8 @@ const ChatHistory: FC = () => {
 
     setFilteredEndedChatsList(
       chatsList.filter((c) => {
-        const created = Date.parse(format(new Date(c.created), 'MM/dd/yyyy'));
-        return created >= startDate && created <= endDate;
+        const ended = Date.parse(format(new Date(c.ended), 'MM/dd/yyyy'));
+        return ended >= startDate && ended <= endDate;
       })
     );
   };


### PR DESCRIPTION
- Update SQL script to use ENDED as criteria not STARTED date.
- Update GUI filter to filter chats on ENDED date.

![image](https://github.com/user-attachments/assets/9b895bed-4ccd-46e8-b514-2573f2e56968)


Related [TASK](https://github.com/buerokratt/Buerokratt-Chatbot/issues/932).