### PR TITLE
1064 History chats date range

### DIFF
--- a/GUI/src/pages/Chat/ChatHistory/index.tsx
+++ b/GUI/src/pages/Chat/ChatHistory/index.tsx
@@ -102,7 +102,7 @@ const ChatHistory: FC = () => {
         : new Date(
             new Date().getUTCFullYear(),
             new Date().getUTCMonth(),
-            new Date().getUTCDate() + 1
+            new Date().getUTCDate()
           ),
     },
   });


### PR DESCRIPTION
- Update initial values to be today on start and end dates.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1064).