### PR TITLE
Fix/1099 markdown support

### DIFF
--- a/GUI/src/components/Chat/Chat.scss
+++ b/GUI/src/components/Chat/Chat.scss
@@ -379,7 +379,7 @@
 .reset {
   margin: 0;
   padding: 0;
-  line-height: 1.5;
+  line-height: 1.3;
 }
 
 .reset h1,
@@ -393,13 +393,13 @@
 }
 
 .reset p {
-  margin: 0;
+  margin:  0 0 0.5rem;
   padding: 0;
 }
 
 .reset ul,
 .reset ol {
-  margin: 0;
+  margin: 0 0 1rem;
   padding-left: 1.5rem;
 }
 

--- a/GUI/src/components/Chat/Chat.scss
+++ b/GUI/src/components/Chat/Chat.scss
@@ -375,3 +375,40 @@
   color: get-color(black-coral-6);
   padding-top: 2px;
 }
+
+.reset {
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+}
+
+.reset h1,
+.reset h2,
+.reset h3,
+.reset h4,
+.reset h5,
+.reset h6 {
+  margin: 0;
+  padding: 0;
+}
+
+.reset p {
+  margin: 0;
+  padding: 0;
+}
+
+.reset ul,
+.reset ol {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.reset li {
+  margin: 0;
+  padding: 0;
+}
+
+.reset a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Markdown from 'markdown-to-jsx';
+import './Chat.scss';
 
 interface MarkdownifyProps {
   message: string | undefined;
@@ -22,7 +23,7 @@ const LinkPreview: React.FC<{ href: string }> = ({ href }) => {
 };
 
 const Markdownify: React.FC<MarkdownifyProps> = ({ message }) => (
-  <div>
+  <div className={'reset'}>
     <Markdown
       options={{
         enforceAtxHeadings: true,


### PR DESCRIPTION
- Added style reset to reflect indentations properly.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1099).