### PR TITLE
1131 Empty messages

### DIFF
--- a/GUI/src/components/ChatEvent/index.tsx
+++ b/GUI/src/components/ChatEvent/index.tsx
@@ -194,6 +194,11 @@ const ChatEvent: FC<ChatEventProps> = ({ message }) => {
         date: format(new Date(message.authorTimestamp), 'dd.MM.yyyy HH:mm:ss'),
       });
       break;
+    case CHAT_EVENTS.READ:
+      EVENT_PARAMS = t('chat.events.read', {
+        date: format(new Date(authorTimestamp), 'dd.MM.yyyy HH:mm:ss'),
+      });
+      break;
     default:
       EVENT_PARAMS = t(`chat.events.${event?.toLowerCase()}`, {
         date: format(new Date(authorTimestamp), 'dd.MM.yyyy HH:mm:ss'),

--- a/GUI/src/components/HistoricalChat/index.tsx
+++ b/GUI/src/components/HistoricalChat/index.tsx
@@ -101,15 +101,6 @@ const HistoricalChat: FC<ChatProps> = ({
     let groupedMessages: GroupedMessage[] = [];
     messagesList.forEach((message) => {
       const lastGroup = groupedMessages[groupedMessages.length - 1];
-      if (
-        lastGroup &&
-        lastGroup.type === AUTHOR_ROLES.BACKOFFICE_USER &&
-        lastGroup.messages.at(-1) &&
-        message.event === CHAT_EVENTS.READ
-      ) {
-        lastGroup.messages.push(message);
-        return;
-      }
       if (lastGroup?.type === message.authorRole) {
         if (
           !message.event ||

--- a/GUI/translations/en/common.json
+++ b/GUI/translations/en/common.json
@@ -241,6 +241,7 @@
       "requested-chat-forward-accepted": "Requested chat forward accepted {{date}}",
       "requested-chat-forward-rejected": "Requested chat forward rejected {{date}}",
       "message-read": "Read",
+      "read": "Read {{ date }}",
       "contact-information-skipped": "Contact Information Skipped",
       "unavailable-contact-information-fulfilled": "Contact information provided",
       "unavailable_organization": "Organization is unavailable",

--- a/GUI/translations/et/common.json
+++ b/GUI/translations/et/common.json
@@ -241,6 +241,7 @@
       "requested-chat-forward-accepted": "Vestluse suunamine aktsepteeritud {{date}}",
       "requested-chat-forward-rejected": "Vestluse suunamine tagasi lükatud {{date}}",
       "message-read": "Loetud",
+      "read": "Loetud {{ date }}",
       "contact-information-skipped": "Kontaktandmeid ei saadetud",
       "unavailable-contact-information-fulfilled": "Kontaktandmed on antud",
       "unavailable_organization": "Asutus ei ole kättesaadav",


### PR DESCRIPTION
- Empty bubble was trying to display 'READ' event, now displaying

Related [task.](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1131)