### PR TITLE
Hot-Fix: End-user messages not visible in chat history

### DIFF
--- a/GUI/package.json
+++ b/GUI/package.json
@@ -14,7 +14,7 @@
     "@buerokratt-ria/header": "^0.1.24",
     "@buerokratt-ria/menu": "^0.2.6",
     "@buerokratt-ria/styles": "^0.0.1",
-    "@buerokratt-ria/common-gui-components": "^0.0.5",
+    "@buerokratt-ria/common-gui-components": "^0.0.7",
     "@fontsource/roboto": "^4.5.8",
     "@formkit/auto-animate": "^1.0.0-beta.5",
     "@fortaine/fetch-event-source": "^3.0.6",


### PR DESCRIPTION
Related Task:

- https://github.com/buerokratt/Buerokratt-Chatbot/issues/1239