### PR TITLE
965 History page size

### DIFF
--- a/GUI/package.json
+++ b/GUI/package.json
@@ -14,7 +14,7 @@
     "@buerokratt-ria/header": "^0.1.36",
     "@buerokratt-ria/menu": "^0.2.6",
     "@buerokratt-ria/styles": "^0.0.1",
-    "@buerokratt-ria/common-gui-components": "^0.0.17",
+    "@buerokratt-ria/common-gui-components": "^0.0.20",
     "@fontsource/roboto": "^4.5.8",
     "@formkit/auto-animate": "^1.0.0-beta.5",
     "@fortaine/fetch-event-source": "^3.0.6",


### PR DESCRIPTION
- Updated history package to 0.0.20

Related [task](https://github.com/buerokratt/Training-Module/issues/965).