### PR TITLE
1528 asking consent

### DIFF
--- a/DSL/Resql/backoffice/POST/get-chat-messages.sql
+++ b/DSL/Resql/backoffice/POST/get-chat-messages.sql
@@ -14,6 +14,7 @@ FilteredMessages AS (
     FROM MessageChain mc
     LEFT JOIN MessageChain mc2 ON mc.base_id = mc2.original_base_id
     WHERE mc2.base_id IS NULL
+    ORDER BY mc.base_id,mc.author_timestamp DESC
 ),
 LatestActiveUser AS (
   SELECT

--- a/DSL/Resql/backoffice/POST/get-chat-messages.sql
+++ b/DSL/Resql/backoffice/POST/get-chat-messages.sql
@@ -17,6 +17,7 @@ FilteredMessages AS (
 ),
 LatestActiveUser AS (
   SELECT
+ORDER BY mc.base_id,mc.author_timestamp DESC
     u.id_code, u.created, u.csa_title
   FROM
     "user" u INNER JOIN (

--- a/DSL/Resql/backoffice/POST/get-chat-messages.sql
+++ b/DSL/Resql/backoffice/POST/get-chat-messages.sql
@@ -18,7 +18,6 @@ FilteredMessages AS (
 ),
 LatestActiveUser AS (
   SELECT
-ORDER BY mc.base_id,mc.author_timestamp DESC
     u.id_code, u.created, u.csa_title
   FROM
     "user" u INNER JOIN (


### PR DESCRIPTION
- Updated SQL, added timestamp ordering so it would take latest and it would be usually consent of user unless theres some change in the logic it would be written in.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1528).