### PR TITLE
1509 tooltip session lenght

### DIFF
--- a/GUI/src/pages/Settings/SettingsSessionLength/index.tsx
+++ b/GUI/src/pages/Settings/SettingsSessionLength/index.tsx
@@ -294,7 +294,7 @@ const SettingsSessionLength: FC = () => {
                         />
                       )}
                     />
-                      {getTooltip('settings.sessionLength.tooltip.showEndMessage')}
+                      {getTooltip('idleMessageText')}
                     </Track>
                   )}
                 </>


### PR DESCRIPTION
- Fixed parameter passed to the tool tip function.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1509)