### PR TITLE
1187 terminate unended chats

### DIFF
--- a/DSL/Resql/backoffice/POST/get-dead-chat-ids.sql
+++ b/DSL/Resql/backoffice/POST/get-dead-chat-ids.sql
@@ -7,4 +7,5 @@ FROM (
          ORDER BY base_id, updated DESC
      ) latest
 WHERE latest.status IS NOT NULL
-  AND latest.status <> 'ENDED';
+  AND latest.status <> 'ENDED'
+  AND latest.ended IS NULL;

--- a/DSL/Ruuter.private/backoffice/GET/cron-tasks/end-dead-chats.yml
+++ b/DSL/Ruuter.private/backoffice/GET/cron-tasks/end-dead-chats.yml
@@ -33,7 +33,7 @@ checkTimIds:
   result: deadKeys
 
 returnSuccess:
-  return: ${JSON.parse(deadKeys.response.body)}
+  return: ${deadKeys.response.body}
   next: end
 
 return_not_found:


### PR DESCRIPTION
- Updated SQL to go back week and ignore idle chats
- Update DSL to process tim response with new changes.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1187).