### PR TITLE
Changes related to a bug fix in service-module #932 [Broken Links & HTML Artifacts in Message to Client]

### DIFF
--- a/DSL/DMapper/backoffice/hbs/bot_responses_to_messages.handlebars
+++ b/DSL/DMapper/backoffice/hbs/bot_responses_to_messages.handlebars
@@ -2,7 +2,7 @@
 {{#each data.botMessages}}
   {
    "chatId": "{{../data.chatId}}",
-   "content": "{{filterControlCharacters (choose text result)}}",
+  "content": "{{{filterControlCharacters (escapeQuotes (choose text result))}}}",
    "buttons": "[{{#each buttons}}{\"title\": \"{{{title}}}\",\"payload\": \"{{{payload}}}\"}{{#unless @last}},{{/unless}}{{/each}}]",
    "authorTimestamp": "{{../data.authorTimestamp}}",
    "authorId": "{{../data.authorId}}",

--- a/DSL/Ruuter.public/backoffice/POST/internal/message-to-bot.yml
+++ b/DSL/Ruuter.public/backoffice/POST/internal/message-to-bot.yml
@@ -132,7 +132,7 @@ assign_with_parsed_buttons:
       - recipient_id: ${chatId}
         text: ${responseContent}
         buttons: ${JSON.parse(responseButtons)}
-  next: format_bot_messages
+  next: normalize_html_links_in_bot_messages
 
 assign_without_buttons:
   assign:
@@ -140,14 +140,14 @@ assign_without_buttons:
       - recipient_id: ${chatId}
         text: ${responseContent}
         buttons: []
-  next: format_bot_messages
+  next: normalize_html_links_in_bot_messages
 
 assign_simple_response:
   assign:
     botMsg:
       - recipient_id: ${chatId}
         text: ${llm_service_response.response.body.response}
-  next: format_bot_messages
+  next: normalize_html_links_in_bot_messages
 
 check_for_service:
   switch:
@@ -479,12 +479,17 @@ add_chat_id_to_queue_notification_node:
 extract_bot_responses_after_redirect_to_back_office:
   assign:
     botMsg: ${post_message_to_bot_result.response.body}
-  next: format_bot_messages
+  next: normalize_html_links_in_bot_messages
 
 extract_bot_responses:
   assign:
     botMsg: ${post_message_to_bot_result.response.body}
     botMsgTxt: ${post_message_to_bot_result.response.body?.[0]?.text}
+  next: normalize_html_links_in_bot_messages
+
+normalize_html_links_in_bot_messages:
+  assign:
+    botMsg: '$=botMsg.map(m => { const cvt = v => (v||"").replace(/<a\s[^>]*href="([^"]+)"[^>]*>([\s\S]*?)(?:<\/a>|$)/gi, (_, u, l) => "[" + l.replace(/<[^>]+>/g,"").trim() + "](" + u + ")"); return {...m, text: cvt(m.text), result: cvt(m.result)}; })='
   next: format_bot_messages
 
 format_bot_messages:

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -72,6 +72,16 @@ const LinkPreview: React.FC<{
 
 const hasSpecialFormat = (m: string) => m.includes('\n\n') && m.indexOf('.') > 0 && m.indexOf(':') > m.indexOf('.');
 
+const htmlLinkToMarkdown = (value: string): string =>
+  value.replaceAll(
+    /<a\s+[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi,
+    (_, href1: string, href2: string, href3: string, label: string) => {
+      const href = (href1 ?? href2 ?? href3 ?? '').trim();
+      const text = sanitizeHtml(label ?? '', { allowedTags: [], allowedAttributes: {} }).trim() || href;
+      return href ? `[${text}](${href})` : text;
+    },
+  );
+
 function formatMessage(message?: string): string {
   const sanitizedMessage = sanitizeHtml(message ?? '');
 
@@ -87,8 +97,9 @@ function formatMessage(message?: string): string {
     dataImagePattern,
     (_, prefix, dataUrl) => `${prefix}[image](${dataUrl})`,
   );
+  const markdownLinksMessage = htmlLinkToMarkdown(finalMessage);
 
-  return finalMessage
+  return markdownLinksMessage
     .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -100,7 +100,7 @@ function formatMessage(message?: string): string {
   const markdownLinksMessage = htmlLinkToMarkdown(finalMessage);
 
   return markdownLinksMessage
-    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
+    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')
     .replaceAll('&lt;', '<')
@@ -116,7 +116,7 @@ function formatMessage(message?: string): string {
           return `${prefix}${year}. `;
         }
       }
-      return `${prefix}${year}\\. `;
+      return String.raw`${prefix}${year}\. `;
     })
     .replaceAll(/(?<=\n)\d+\.\s/g, hasSpecialFormat(finalMessage) ? '\n\n$&' : '$&')
     .replaceAll(/^(\s+)/g, (match) => match.replaceAll(' ', '&nbsp;'));

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -72,15 +72,21 @@ const LinkPreview: React.FC<{
 
 const hasSpecialFormat = (m: string) => m.includes('\n\n') && m.indexOf('.') > 0 && m.indexOf(':') > m.indexOf('.');
 
-const htmlLinkToMarkdown = (value: string): string =>
-  value.replaceAll(
-    /<a\s+[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi,
-    (_, href1: string, href2: string, href3: string, label: string) => {
-      const href = (href1 ?? href2 ?? href3 ?? '').trim();
-      const text = sanitizeHtml(label ?? '', { allowedTags: [], allowedAttributes: {} }).trim() || href;
-      return href ? `[${text}](${href})` : text;
-    },
-  );
+const htmlLinkToMarkdown = (value: string): string => {
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = value;
+  const links = tempDiv.querySelectorAll('a');
+  
+  let result = value;
+  links.forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    const text = link.textContent || href;
+    const markdown = href ? `[${text}](${href})` : text;
+    result = result.replace(link.outerHTML, markdown);
+  });
+  
+  return result;
+};
 
 function formatMessage(message?: string): string {
   const sanitizedMessage = sanitizeHtml(message ?? '');


### PR DESCRIPTION
https://github.com/buerokratt/Service-Module/issues/932

This pull request introduces improvements to how bot messages handle HTML links, ensuring that any links in bot responses are consistently converted to Markdown format. The changes affect both the backend processing of bot messages and the frontend rendering logic, resulting in clearer and more user-friendly link presentation.

**Backend link normalization:**
* Added a new `normalize_html_links_in_bot_messages` step in `DSL/Ruuter.public/backoffice/POST/internal/message-to-bot.yml` that converts HTML `<a>` tags in bot message fields (`text`, `result`) to Markdown links before formatting messages. This step is now used in place of the previous `format_bot_messages` step in multiple assignment flows. [[1]](diffhunk://#diff-9b4e76f4e6b6bead19773ef2b663647204bf68bba25ceb709b90b540e64d71abL135-R150) [[2]](diffhunk://#diff-9b4e76f4e6b6bead19773ef2b663647204bf68bba25ceb709b90b540e64d71abL482-R492)
* Updated the `bot_responses_to_messages.handlebars` template to escape quotes in bot message content, improving robustness when handling special characters.

**Frontend link conversion:**
* Added the `htmlLinkToMarkdown` function in `GUI/src/components/Chat/Markdownify.tsx` to convert HTML `<a>` tags to Markdown links during message formatting.
* Modified the `formatMessage` function to use `htmlLinkToMarkdown`, ensuring that rendered messages display links in Markdown format rather than raw HTML.