### PR TITLE
Fix/html link isuue

### DIFF
--- a/DSL/Ruuter.public/backoffice/POST/internal/message-to-bot.yml
+++ b/DSL/Ruuter.public/backoffice/POST/internal/message-to-bot.yml
@@ -489,7 +489,7 @@ extract_bot_responses:
 
 normalize_html_links_in_bot_messages:
   assign:
-    botMsg: '$=botMsg.map(m => { const cvt = v => (v||"").replace(/<a\s[^>]*href="([^"]+)"[^>]*>([\s\S]*?)(?:<\/a>|$)/gi, (_, u, l) => "[" + l.replace(/<[^>]+>/g,"").trim() + "](" + u + ")"); return {...m, text: cvt(m.text), result: cvt(m.result)}; })='
+    botMsg: '$=botMsg.map(m => { const cvt = v => (v||"").replace(/<a\s[^>]*href="([^"]+)"[^>]*>([\s\S]*?)(?:<\/a>|$)/gi, (_, u, l) => { const abs = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//i.test(u) || u.startsWith("//") ? u : "https://" + u; return "[" + l.replace(/<[^>]+>/g,"").trim() + "](" + abs + ")"; }); return {...m, text: cvt(m.text), result: cvt(m.result)}; })='
   next: format_bot_messages
 
 format_bot_messages:

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -28,6 +28,13 @@ const isValidImageUrl = (s: string): boolean => {
   }
 };
 
+const ensureAbsoluteUrl = (href: string): string => {
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//i.test(href) || href.startsWith('//')) {
+    return href;
+  }
+  return `https://${href}`;
+};
+
 const LinkPreview: React.FC<{
   href: string;
   children: React.ReactNode;
@@ -42,7 +49,7 @@ const LinkPreview: React.FC<{
 
   if (sanitizeLinks) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer">
+      <a href={ensureAbsoluteUrl(href)} target="_blank" rel="noopener noreferrer">
         {href}
       </a>
     );
@@ -50,7 +57,7 @@ const LinkPreview: React.FC<{
 
   if (!isValidImageUrl(href)) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer">
+      <a href={ensureAbsoluteUrl(href)} target="_blank" rel="noopener noreferrer">
         {children}
       </a>
     );
@@ -81,7 +88,7 @@ const htmlLinkToMarkdown = (value: string): string => {
   links.forEach((link) => {
     const href = link.getAttribute('href') || '';
     const text = link.textContent || href;
-    const markdown = href ? `[${text}](${href})` : text;
+    const markdown = href ? `[${text}](${ensureAbsoluteUrl(href)})` : text;
     result = result.replace(link.outerHTML, markdown);
   });
   

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -29,7 +29,7 @@ const isValidImageUrl = (s: string): boolean => {
 };
 
 const ensureAbsoluteUrl = (href: string): string => {
-  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//i.test(href) || href.startsWith('//')) {
+  if (/^[a-z][a-z\d+\-.]*:\/\//i.test(href) || href.startsWith('//')) {
     return href;
   }
   return `https://${href}`;

--- a/GUI/src/components/Chat/Markdownify.tsx
+++ b/GUI/src/components/Chat/Markdownify.tsx
@@ -83,7 +83,7 @@ const htmlLinkToMarkdown = (value: string): string => {
   const tempDiv = document.createElement('div');
   tempDiv.innerHTML = value;
   const links = tempDiv.querySelectorAll('a');
-  
+
   let result = value;
   links.forEach((link) => {
     const href = link.getAttribute('href') || '';
@@ -91,7 +91,7 @@ const htmlLinkToMarkdown = (value: string): string => {
     const markdown = href ? `[${text}](${ensureAbsoluteUrl(href)})` : text;
     result = result.replace(link.outerHTML, markdown);
   });
-  
+
   return result;
 };
 


### PR DESCRIPTION
This pull request improves the handling of HTML links in bot messages and the chat UI by ensuring all URLs are absolute, which helps prevent broken or insecure links. The changes affect both backend processing of bot messages and frontend rendering in the chat component.

**Link normalization and URL handling improvements:**

* Updated the backend normalization logic in `DSL/Ruuter.public/backoffice/POST/internal/message-to-bot.yml` to convert all relative URLs in bot messages to absolute URLs by prepending `https://` when necessary.
* Added a new `ensureAbsoluteUrl` utility function in `GUI/src/components/Chat/Markdownify.tsx` to standardize URL formatting on the frontend.

**Frontend link rendering updates:**

* Modified the `LinkPreview` component to use `ensureAbsoluteUrl` for all rendered links, ensuring that anchor tags always have absolute URLs.
* Updated the `htmlLinkToMarkdown` function to convert HTML links to Markdown with absolute URLs by using `ensureAbsoluteUrl`.